### PR TITLE
Multilingual toggle

### DIFF
--- a/writing_center/appointments/appointments_controller.py
+++ b/writing_center/appointments/appointments_controller.py
@@ -92,7 +92,7 @@ class AppointmentsController:
         except Exception as e:
             return False
 
-    def begin_walk_in_appointment(self, user, tutor, course, assignment):
+    def begin_walk_in_appointment(self, user, tutor, course, assignment, multilingual):
         if course:
             course_code = course['course_code']
             course_section = course['section']
@@ -101,11 +101,11 @@ class AppointmentsController:
             begin_appt = AppointmentsTable(student_id=user.id, tutor_id=tutor.id, scheduledStart=datetime.now(),
                                            actualStart=datetime.now(), profName=prof_name, profEmail=prof_email,
                                            assignment=assignment, courseCode=course_code, courseSection=course_section,
-                                           inProgress=1, dropIn=1, sub=0, multilingual=0, noShow=0)
+                                           inProgress=1, dropIn=1, sub=0, multilingual=multilingual, noShow=0)
         else:
             begin_appt = AppointmentsTable(student_id=user.id, tutor_id=tutor.id, scheduledStart=datetime.now(),
                                            actualStart=datetime.now(), assignment=assignment, inProgress=1, dropIn=1,
-                                           sub=0, multilingual=0, noShow=0)
+                                           sub=0, multilingual=multilingual, noShow=0)
         db_session.add(begin_appt)
         db_session.commit()
         return begin_appt
@@ -144,6 +144,16 @@ class AppointmentsController:
             .filter(AppointmentsTable.id == appt_id)\
             .one_or_none()
         appointment.noShow = 0
+        db_session.commit()
+
+    def mark_multilingual(self, appt_id):
+        appointment = db_session.query(AppointmentsTable).filter(AppointmentsTable.id == appt_id).one_or_none()
+        appointment.multilingual = 1
+        db_session.commit()
+
+    def revert_multilingual(self, appt_id):
+        appointment = db_session.query(AppointmentsTable).filter(AppointmentsTable.id == appt_id).one_or_none()
+        appointment.multilingual = 0
         db_session.commit()
 
     def ban_if_no_show_check(self, user_id):

--- a/writing_center/templates/appointments/appointment_sign_in.html
+++ b/writing_center/templates/appointments/appointment_sign_in.html
@@ -5,7 +5,7 @@
     </div>
     <form action="{{ url_for('AppointmentsView:begin_walk_in') }}" method="post">
         <div class="form-row">
-            <div class="col-md-5">
+            <div class="col-md-4">
                 <div class="form-group">
                     <input id="username" type="hidden" value="{{ username }}" name="username">
                     <label for="course">Course/Reason:</label>
@@ -17,10 +17,23 @@
                     </select>
                 </div>
             </div>
-            <div class="col-md-5">
+            <div class="col-md-4">
                 <div class="form-group">
                     <label for="assignment">Assignment:</label>
                     <textarea id="assignment" name="assignment" class="form-control"></textarea>
+                </div>
+            </div>
+            <div class="col-md-4">
+                <div class="form-group">
+                    <label>Multilingual:</label>
+                    <div class="form-check">
+                        <input class="form-check-input" type="radio" name="multi" id="multi-yes" value="1">
+                        <label class="form-check-label" for="multi-yes">Yes</label>
+                    </div>
+                    <div class="form-check">
+                        <input class="form-check-input" type="radio" name="multi" id="multi-no" value="0" checked>
+                        <label class="form-check-label" for="multi-no">No</label>
+                    </div>
                 </div>
             </div>
         </div>

--- a/writing_center/templates/appointments/appointments_and_walk_ins.html
+++ b/writing_center/templates/appointments/appointments_and_walk_ins.html
@@ -40,6 +40,7 @@
                         <th data-toggle="tooltip" data-placement="top" title="End Time">End Time</th>
                         <th data-toggle="tooltip" data-placement="top" title="Start Appointment">Start/Continue Appointment</th>
                         <th data-toggle="tooltip" data-placement="top" title="Mark/Unmark as No Show">Mark/Unmark as No Show</th>
+                        <th data-toggle="tooltip" data-placement="top" title="Mark/Unmark as Multilingual">Mark/Unmark as Multilingual</th>
                         <th data-toggle="tooltip" data-placement="top" title="View More Info">View More Info</th>
                     </tr>
                 </thead>
@@ -75,6 +76,15 @@
                                     {% elif appointment.noShow == 1 %}
                                         <a id="revert-no-show" href="{{ url_for('AppointmentsView:toggle_no_show', appt_id=appointment.id) }}"
                                            class="btn btn-primary btn-danger">Revert No Show</a>
+                                    {% endif %}
+                                </td>
+                                <td>
+                                    {% if appointment.multilingual == 0 or not appointment.multilingual %}
+                                        <a id="multilingual" href="{{ url_for('AppointmentsView:toggle_multilingual', appt_id=appointment.id) }}"
+                                           class="btn btn-primary btn-danger">Mark as Multilingual</a>
+                                    {% elif appointment.multilingual == 1 %}
+                                        <a id="revert-multilingual" href="{{ url_for('AppointmentsView:toggle_multilingual', appt_id=appointment.id) }}"
+                                           class="btn btn-primary btn-danger">Revert Multilingual</a>
                                     {% endif %}
                                 </td>
                                 <td><input type="button" class="btn btn-primary darkblue" value="More Info" onclick="viewInfo({{ appointment.id }})"></td>


### PR DESCRIPTION
## Description

April wanted a way to mark walk-ins and scheduled appointments as multilingual once the student is there in case they need that service but don't mark it when they sign up.

## Size and Type of change

- Small Change - 1 person needs to review this

- New feature

## How Has This Been Tested?

Locally

## Checklist:

Only check what applies and what you have done.

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have tested on multiple browsers (Chrome, Firefox, Safari, IE suite)
