### PR TITLE
fixed recipients not pulling all recipient groups

### DIFF
--- a/writing_center/message_center/__init__.py
+++ b/writing_center/message_center/__init__.py
@@ -32,7 +32,7 @@ class MessageCenterView(FlaskView):
         # need to check that all the stuff is actually filled in, if its not, we need to fill it with an empty value
         subject = data.get('subject')
         message = data.get('message')
-        recipients = data.get('recipients')
+        recipients = data.getlist('recipients')
         cc = data.get('cc')
         bcc = data.get('bcc')
         if self.base.send_message(subject, message, recipients, cc, bcc):


### PR DESCRIPTION
## Description

Changed the recipient get function to getlist so it gets all the selected groups for message center emails

## Size and Type of change

- Extra Small Change - 1 person can review

- Bug fix

## How Has This Been Tested?

- Locally, ran in debug mode and saw that it was pulling in a list versus a single value

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have tested on multiple browsers (Chrome, Firefox, Safari, IE suite)
