### PR TITLE
end in progress check

### DIFF
--- a/writing_center/appointments/__init__.py
+++ b/writing_center/appointments/__init__.py
@@ -103,6 +103,8 @@ class AppointmentsView(FlaskView):
         self.wcc.check_roles_and_route(['Tutor', 'Administrator'])
         tutor = flask_session['USERNAME']
         appointments = self.ac.get_scheduled_appointments(tutor)
+        in_progress_appointments = self.ac.get_in_progress_appointments(tutor)
+        appointments.extend(in_progress_appointments)
         users = {}
         for appt in appointments:
             user = self.ac.get_user_by_id(appt.student_id)

--- a/writing_center/appointments/appointments_controller.py
+++ b/writing_center/appointments/appointments_controller.py
@@ -121,6 +121,14 @@ class AppointmentsController:
             .filter(AppointmentsTable.tutor_id == tutor.id)\
             .all()
 
+    def get_in_progress_appointments(self, username):
+        tutor = self.get_user_by_username(username)
+        return db_session.query(AppointmentsTable)\
+            .filter(AppointmentsTable.scheduledEnd == None)\
+            .filter(AppointmentsTable.student_id != None)\
+            .filter(AppointmentsTable.tutor_id == tutor.id)\
+            .all()
+
     def tutor_change_appt(self, appt_id, assignment, notes, suggestions):
         try:
             appt = self.get_appointment_by_id(appt_id)

--- a/writing_center/templates/appointments/appointments_and_walk_ins.html
+++ b/writing_center/templates/appointments/appointments_and_walk_ins.html
@@ -38,7 +38,7 @@
                         <th data-toggle="tooltip" data-placement="top" title="Date">Date</th>
                         <th data-toggle="tooltip" data-placement="top" title="Start Time">Start Time</th>
                         <th data-toggle="tooltip" data-placement="top" title="End Time">End Time</th>
-                        <th data-toggle="tooltip" data-placement="top" title="Start Appointment">Start/Continue Appointment</th>
+                        <th data-toggle="tooltip" data-placement="top" title="Start Appointment">Start/Continue/End Appointment</th>
                         <th data-toggle="tooltip" data-placement="top" title="Mark/Unmark as No Show">Mark/Unmark as No Show</th>
                         <th data-toggle="tooltip" data-placement="top" title="Mark/Unmark as Multilingual">Mark/Unmark as Multilingual</th>
                         <th data-toggle="tooltip" data-placement="top" title="View More Info">View More Info</th>
@@ -64,6 +64,9 @@
                                     {% if not appointment.actualStart %}
                                         <a id="start" href="{{ url_for('AppointmentsView:start_appointment', appt_id=appointment.id) }}"
                                            class="btn btn-primary btn-success">Start Appointment</a>
+                                    {% elif not appointment.actualEnd %}
+                                        <a id="End" href="{{ url_for('AppointmentsView:in_progress_appointment', appt_id=appointment.id) }}"
+                                           class="btn btn-primary btn-danger">End Appointment</a>
                                     {% else %}
                                         <a id="continue" href="{{ url_for('AppointmentsView:in_progress_appointment', appt_id=appointment.id) }}"
                                            class="btn btn-primary background-blue">Continue Appointment</a>

--- a/writing_center/templates/appointments/in_progress_appointment.html
+++ b/writing_center/templates/appointments/in_progress_appointment.html
@@ -63,7 +63,7 @@
                     </div>
                 </div>
                 <div class="form-row">
-                    <button type="submit" class="btn btn-primary">End Appointment</button>
+                    <button type="submit" class="btn btn-danger">End Appointment</button>
                 </div>
             </form>
         </div>


### PR DESCRIPTION
## Description

While I was investigating how to fix something, I came across the issue that if you leave the in_progress_appointment there wasn't any apparent way to end that appointment or go back to the in-progress page (at least without hitting the back button in the browser), so I thought it would be a good idea to add a way to get back to that page if the appointment hasn't been ended yet.

## Size and Type of change

- Small Change - 1 person needs to review this

- New feature

## How Has This Been Tested?

Please briefly describe the tests that you ran to verify your changes.

Locally it works

## Checklist:

Only check what applies and what you have done.

- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have tested on multiple browsers (Chrome, Firefox, Safari, IE suite)
