### PR TITLE
April Requested Changes

### DIFF
--- a/writing_center/appointments/__init__.py
+++ b/writing_center/appointments/__init__.py
@@ -68,6 +68,8 @@ class AppointmentsView(FlaskView):
         if schedule_appt:
             time_limit = int(self.ac.get_time_limit()[0])
             range_appointments = self.ac.get_open_appointments_in_range(start, end, time_limit)
+            open_no_show_appts = self.ac.get_no_show_appointments_in_range(start, end, time_limit)
+            range_appointments.extend(open_no_show_appts)
         else:
             range_appointments = self.ac.get_appointments_in_range(start, end)
             walk_in_appointments = self.ac.get_walk_in_appointments_in_range(start, end)

--- a/writing_center/appointments/appointments_controller.py
+++ b/writing_center/appointments/appointments_controller.py
@@ -64,6 +64,16 @@ class AppointmentsController:
             appointment = db_session.query(AppointmentsTable)\
                 .filter(AppointmentsTable.id == appt_id)\
                 .one_or_none()
+
+            appointment.profName = None
+            appointment.profEmail = None
+            appointment.assignment = None
+            appointment.notes = None
+            appointment.suggestions = None
+            appointment.courseCode = None
+            appointment.courseSection = None
+            appointment.noShow = 0
+
             # Updates the student username
             user = self.get_user_by_username(flask_session['USERNAME'])
             appointment.student_id = user.id
@@ -248,6 +258,17 @@ class AppointmentsController:
             .filter(AppointmentsTable.tutor_id != None)\
             .filter(AppointmentsTable.student_id == None)\
             .all()
+
+    def get_no_show_appointments_in_range(self, start, end, time_limit):
+            time_limit = datetime.now() + timedelta(hours=time_limit)
+            return db_session.query(AppointmentsTable) \
+                .filter(AppointmentsTable.scheduledStart >= start) \
+                .filter(AppointmentsTable.scheduledEnd >= time_limit) \
+                .filter(AppointmentsTable.scheduledEnd <= end) \
+                .filter(AppointmentsTable.tutor_id != None) \
+                .filter(AppointmentsTable.student_id != None) \
+                .filter(AppointmentsTable.noShow) \
+                .all()
 
     def get_future_user_appointments(self, user_id):
         return db_session.query(AppointmentsTable)\

--- a/writing_center/appointments/appointments_controller.py
+++ b/writing_center/appointments/appointments_controller.py
@@ -252,8 +252,8 @@ class AppointmentsController:
     def get_open_appointments_in_range(self, start, end, time_limit):
         time_limit = datetime.now() + timedelta(hours=time_limit)
         return db_session.query(AppointmentsTable) \
-            .filter(AppointmentsTable.scheduledStart >= time_limit)\
             .filter(AppointmentsTable.scheduledStart >= start)\
+            .filter(AppointmentsTable.scheduledEnd >= time_limit)\
             .filter(AppointmentsTable.scheduledEnd <= end)\
             .filter(AppointmentsTable.tutor_id != None)\
             .filter(AppointmentsTable.student_id == None)\

--- a/writing_center/templates/settings/index.html
+++ b/writing_center/templates/settings/index.html
@@ -37,7 +37,7 @@
                     <div class="card settings-card">
                         <div class="card-body">
                             <h5>Time Limit</h5>
-                            <p>Each appointment closes sign-ups {{ setting.value }} hours before the start time.</p>
+                            <p>Each appointment closes sign-ups {{ setting.value }} hours before the end time.</p>
                             <div class="input-group mb-3">
                                 <input id="time-limit" type="text" class="form-control" value="{{ setting.value }}" disabled aria-describedby="edit-time-limit">
                                 <div class="input-group-append">


### PR DESCRIPTION
## Description

Made it so that unscheduled appointments that are past their start time, but not past their end time still show up on the "schedule appointment" tab. 

Made it so that scheduled appointments marked as no show show up on the "schedule appointment" tab.

Changed description of "Time Limit" since it now uses the appointment end time instead of the appointment start time

## Size and Type of change

- Small Change - 1 person needs to review this

## How Has This Been Tested?

Locally I made sure that appointments that have started, but not ended and aren't scheduled show up on the "schedule appointment" tab. Also I tested to make sure that if a person is marked as "no-show" on an appointment, then it shows up on the schedule page again.

## Checklist:

- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have tested on multiple browsers (Chrome, Firefox, Safari, IE suite)
