### PR TITLE
Connect emails to Writing Center

### DIFF
--- a/writing_center/appointments/__init__.py
+++ b/writing_center/appointments/__init__.py
@@ -420,6 +420,7 @@ class AppointmentsView(FlaskView):
 
         try:
             self.ac.end_appointment(appt_id, course, assignment, notes, suggestions)
+            self.mcc.close_session_student(appt_id)
             if ferpa_agreement:
                 self.mcc.end_appt_prof(appt_id)
             qualtrics_link = self.ac.get_survey_link()[0]

--- a/writing_center/message_center/__init__.py
+++ b/writing_center/message_center/__init__.py
@@ -44,17 +44,3 @@ class MessageCenterView(FlaskView):
         else:
             self.wcc.set_alert('danger', 'Email failed to send.')
         return redirect(url_for('MessageCenterView:index'))
-
-    @route('/close-student', methods=['POST'])
-    def close_session_student(self):  # this needs to be connected to the appointment end page
-        # TODO ADD CORRECT ROLES TO ROUTE CHECK BELOW
-        # self.wcc.check_roles_and_route(['Administrator'])
-        data = request.form
-        return self.base.close_session_student(data['appointment_id'])
-
-    @route('/close-tutor', methods=['POST'])
-    def close_session_tutor(self):  # this needs to be connected to the appointment end page
-        # TODO ADD CORRECT ROLES TO ROUTE CHECK BELOW
-        # self.wcc.check_roles_and_route(['Administrator'])
-        data = request.form
-        return self.base.close_session_tutor(data['appointment_id'], data['to_prof'])

--- a/writing_center/message_center/message_center_controller.py
+++ b/writing_center/message_center/message_center_controller.py
@@ -91,7 +91,7 @@ class MessageCenterController:
 
         appt_info = {'tutor': tutor.firstName + " " + tutor.lastName,
                      'date': appointment.scheduledStart.date().strftime("%m/%d/%Y"),
-                     'time': appointment.scheduledStart.time().strftime("%I:%M %p"),
+                     'time': appointment.scheduledStart.time().strftime("%I:%M %p") + " - " + appointment.scheduledEnd.time().strftime("%I:%M %p"),
                      'assignment': appointment.assignment,
                      'notes': appointment.notes,
                      'suggestions': appointment.suggestions}

--- a/writing_center/message_center/message_center_controller.py
+++ b/writing_center/message_center/message_center_controller.py
@@ -89,12 +89,21 @@ class MessageCenterController:
         student = self.get_user_by_id(appointment.student_id)
         tutor = self.get_user_by_id(appointment.tutor_id)
 
-        appt_info = {'tutor': tutor.firstName + " " + tutor.lastName,
-                     'date': appointment.scheduledStart.date().strftime("%m/%d/%Y"),
-                     'time': appointment.scheduledStart.time().strftime("%I:%M %p") + " - " + appointment.scheduledEnd.time().strftime("%I:%M %p"),
-                     'assignment': appointment.assignment,
-                     'notes': appointment.notes,
-                     'suggestions': appointment.suggestions}
+        if appointment.scheduledStart and appointment.scheduledEnd:
+            appt_info = {'tutor': tutor.firstName + " " + tutor.lastName,
+                         'date': appointment.scheduledStart.date().strftime("%m/%d/%Y"),
+                         'time': appointment.scheduledStart.time().strftime("%I:%M %p") + " - " + appointment.scheduledEnd.time().strftime("%I:%M %p"),
+                         'assignment': appointment.assignment,
+                         'notes': appointment.notes,
+                         'suggestions': appointment.suggestions}
+        elif appointment.actualStart and appointment.actualEnd:
+            appt_info = {'tutor': tutor.firstName + " " + tutor.lastName,
+                         'date': appointment.actualStart.date().strftime("%m/%d/%Y"),
+                         'time': appointment.actualStart.time().strftime("%I:%M %p") + " - " + appointment.actualEnd.time().strftime("%I:%M %p"),
+                         'assignment': appointment.assignment,
+                         'notes': appointment.notes,
+                         'suggestions': appointment.suggestions}
+
 
         subject = 'Appointment with {0} {1}'.format(tutor.firstName, tutor.lastName)
 

--- a/writing_center/message_center/message_center_controller.py
+++ b/writing_center/message_center/message_center_controller.py
@@ -89,9 +89,9 @@ class MessageCenterController:
         student = self.get_user_by_id(appointment.student_id)
         tutor = self.get_user_by_id(appointment.tutor_id)
 
-        appt_info = {'tutor': tutor.firstName + tutor.lastName,
-                     'actual_start': appointment.actualStart,
-                     'actual_end': appointment.actualEnd,
+        appt_info = {'tutor': tutor.firstName + " " + tutor.lastName,
+                     'date': appointment.scheduledStart.date().strftime("%m/%d/%Y"),
+                     'time': appointment.scheduledStart.time().strftime("%I:%M %p"),
                      'assignment': appointment.assignment,
                      'notes': appointment.notes,
                      'suggestions': appointment.suggestions}

--- a/writing_center/message_center/message_center_controller.py
+++ b/writing_center/message_center/message_center_controller.py
@@ -84,7 +84,7 @@ class MessageCenterController:
 
         return recipients
 
-    def close_session_student(self, appointment_id):  # todo needs to be connected
+    def close_session_student(self, appointment_id):
         appointment = self.get_appointment_info(appointment_id)
         student = self.get_user_by_id(appointment.student_id)
         tutor = self.get_user_by_id(appointment.tutor_id)

--- a/writing_center/message_center/message_center_controller.py
+++ b/writing_center/message_center/message_center_controller.py
@@ -104,7 +104,6 @@ class MessageCenterController:
                          'notes': appointment.notes,
                          'suggestions': appointment.suggestions}
 
-
         subject = 'Appointment with {0} {1}'.format(tutor.firstName, tutor.lastName)
 
         recipients = student.email

--- a/writing_center/message_center/message_center_controller.py
+++ b/writing_center/message_center/message_center_controller.py
@@ -102,42 +102,6 @@ class MessageCenterController:
 
         self.send_message(subject, render_template('emails/session_email_student.html', **locals()), recipients, bcc='', html=True)
 
-    def close_session_tutor(self, appointment_id, to_prof):  # Todo needs to be connected
-        appointment = self.get_appointment_info(appointment_id)
-        student = self.get_user_by_id(appointment.student_id)
-
-        if appointment.ProfUsername != '':
-            professor = appointment.profName
-        else:
-            professor = 'n/a'
-
-        if appointment.dropIn == 0:
-            appt_type = 'Scheduled'
-        else:
-            appt_type = 'Drop In'
-
-        tutor = self.get_user_by_id(appointment.tutor_id)
-
-        appt_info = {'student': student.FirstName + student.LastName,
-                     'type': appt_type,
-                     'actual_start': appointment.actualStart,
-                     'actual_end': appointment.actualEnd,
-                     'assignment': appointment.assignment}
-
-        subject = 'Appointment with {0} {1}'.format(student.firstName, student.lastName)
-
-        recipients = [tutor.email]
-
-        if to_prof:
-            recipients.append(appointment.profEmail)
-            if self.send_message(subject, render_template('emails/session_email_tutor.html', **locals()), recipients, bcc='', html=True):
-                return True
-            return False
-        else:
-            if self.send_message(subject, render_template('emails/session_email_tutor.html', **locals()), recipients, bcc='', html=True):
-                return True
-            return False
-
     def appointment_signup_student(self, appointment_id):
         # get the appointment via the appointment id
         appointment = self.get_appointment_info(appointment_id)

--- a/writing_center/templates/emails/appointment_signup_student.html
+++ b/writing_center/templates/emails/appointment_signup_student.html
@@ -6,11 +6,9 @@
 
 {% block email_content %}
     <h3>You signed up for an appointment:</h3>
-        <br/>
         <p>Date: {{ appt_info['date']}}</p>
         <p>Your scheduled start time: {{ appt_info['time'] }}</p>
         <p>Tutor: {{ appt_info['tutor'] }}</p>
-        <br/>
         <p>Go to the <a href="https://www.bethel.edu/undergrad/academics/support/writing">Writing Support for CAS</a> page to find out more about the Writing Center's services and resources</p>
         <p>Cancel your appointment <a href="{{ url_for('AppointmentsView:student_view_appointments') }}">here</a></p>
 {% endblock %}

--- a/writing_center/templates/emails/session_email_student.html
+++ b/writing_center/templates/emails/session_email_student.html
@@ -6,15 +6,12 @@
 
 {% block email_content %}
     <h3>Appointment Information:</h3>
-        <br/>
         <p>Tutor: {{ appt_info['tutor'] }}</p>
-        <p>Actual Time: {{ appt_info['actual_start']}}-{{ appt_info['actual_end'] }}</p>
+        <p>Date: {{ appt_info['date']}}</p>
+        <p>Time: {{ appt_info['time'] }}</p>
         <p>Assignment: {{ appt_info['assignment'] }}</p>
-        <br/>
         <p>Notes: {{ appt_info['notes'] }}</p>
-        <br/>
         <p>Suggestions: {{ appt_info['suggetions'] }}</p>
-        <br/>
         <p>Schedule another appointment <a href="{{ url_for('AppointmentsView:schedule_appointment_landing') }}">here</a></p>
         <p>Go to the <a href="https://www.bethel.edu/undergrad/academics/support/writing">Writing Support for CAS</a> page to find out more about the Writing Center's services and resources</p>
 

--- a/writing_center/templates/emails/session_email_student.html
+++ b/writing_center/templates/emails/session_email_student.html
@@ -11,7 +11,7 @@
         <p>Time: {{ appt_info['time'] }}</p>
         <p>Assignment: {{ appt_info['assignment'] }}</p>
         <p>Notes: {{ appt_info['notes'] }}</p>
-        <p>Suggestions: {{ appt_info['suggetions'] }}</p>
+        <p>Suggestions: {{ appt_info['suggestions'] }}</p>
         <p>Schedule another appointment <a href="{{ url_for('AppointmentsView:schedule_appointment_landing') }}">here</a></p>
         <p>Go to the <a href="https://www.bethel.edu/undergrad/academics/support/writing">Writing Support for CAS</a> page to find out more about the Writing Center's services and resources</p>
 

--- a/writing_center/templates/macros/appointment_modal.html
+++ b/writing_center/templates/macros/appointment_modal.html
@@ -137,7 +137,7 @@
                             <th colspan="2"><button class="btn btn-primary btn-danger" onclick="cancelAppointment({{ appt_id }})">Cancel Appointment</button></th>
                         </tr>
                     {% endif %}
-                    {% if pickup_sub_delete and appointment.scheduledStart >= now and ('Administrator' in session['USER-ROLES'] or 'Tutor' in session['USER-ROLES']) %}
+                    {% if pickup_sub_delete and appointment.scheduledStart and appointment.scheduledStart >= now and ('Administrator' in session['USER-ROLES'] or 'Tutor' in session['USER-ROLES']) %}
                         {% if appointment.sub == 0 %}
                             <tr>
                                 <th id="request-sub-container"  colspan="2">

--- a/writing_center/templates/message_center/send-email.html
+++ b/writing_center/templates/message_center/send-email.html
@@ -62,7 +62,7 @@
                 <div class="card-body">
                     <p class="card-text">
                         Send emails to groups using the recipients tab and individuals in the CC/BCC tabs
-                    </p> <!--TODO: Reword this to apply to the writing center stuff-->
+                    </p>
                 </div>
             </div>
         </div>

--- a/writing_center/wsapi/wsapi_controller.py
+++ b/writing_center/wsapi/wsapi_controller.py
@@ -24,17 +24,8 @@ class WSAPIController:
         path = '/username/{0}/roles'.format(username)
         return self.get_hmac_request(path)
 
-    # TODO: I left these in as examples but I don't know which ones we will use
     def get_student_courses(self, username):
         path = '/username/{0}/courses'.format(username)
-        return self.get_hmac_request(path)
-
-    def get_course_info(self, course_dept, course_num):
-        path = '/course/info/{0}/{1}'.format(course_dept, course_num)
-        return self.get_hmac_request(path)
-
-    def validate_course(self, course_dept, course_num):
-        path = '/course/valid/{0}/{1}'.format(course_dept, course_num)
         return self.get_hmac_request(path)
 
     def get_username_from_name(self, first_name, last_name):


### PR DESCRIPTION
## Description

I removed some unused code like emailing tutors on session close (since tutors probably don't care about a session when it ends).

I removed unused wsapi code.

I connected up the end of session emails, since previous to this nothing was working.

## Size and Type of change

- Small Change - 1 person needs to review this

- Bug fix

- New feature

## How Has This Been Tested?

I tested this on xp and made sure I got emails when my session was closed.

## Checklist:

- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [] I have made corresponding changes to the documentation
- [ ] I have tested on multiple browsers (Chrome, Firefox, Safari, IE suite)
