### PR TITLE
Potentially fix inconsistent student name on email/appointment

### DIFF
--- a/writing_center/appointments/__init__.py
+++ b/writing_center/appointments/__init__.py
@@ -182,7 +182,10 @@ class AppointmentsView(FlaskView):
         user = self.ac.get_user_by_username(username)
         tutor = self.ac.get_user_by_username(flask_session['USERNAME'])
         appt = self.ac.begin_walk_in_appointment(user, tutor, course, assignment, multilingual)
-        self.wcc.set_alert('success', 'Appointment for ' + user.firstName + ' ' + user.lastName + ' started')
+        if not appt:
+            self.wcc.set_alert('danger', 'Walk in appointment failed to be started.')
+            return self.appointments_and_walk_ins()
+        self.wcc.set_alert('success', 'Appointment for ' + user.firstName + ' ' + user.lastName + ' started.')
         return redirect(url_for('AppointmentsView:in_progress_appointment', appt_id=appt.id))
 
     @route('search-appointments')

--- a/writing_center/appointments/__init__.py
+++ b/writing_center/appointments/__init__.py
@@ -260,7 +260,7 @@ class AppointmentsView(FlaskView):
         assignment = str(json.loads(request.data).get('assignment'))
         username = flask_session['USERNAME']
         if username in ['Administrator', 'Observer', 'Tutor', 'Student']:
-            self.wcc.set_alert('danger', 'You cannot schedule an appointment while acting as a role')
+            self.wcc.set_alert('danger', 'You cannot schedule an appointment while acting as a role.')
         else:
             # Checks if the user already exists in WC DB. If a user does, we either continue or reactivate them. If they
             # don't exist then we create them
@@ -346,7 +346,7 @@ class AppointmentsView(FlaskView):
         cancelled = self.ac.cancel_appointment(appt_id)
         if cancelled:
             self.mcc.cancel_appointment_student(appt_id)
-            self.wcc.set_alert('success', 'Successfully cancelled appointment')
+            self.wcc.set_alert('success', 'Successfully cancelled appointment.')
         else:
             self.wcc.set_alert('danger', 'Failed to cancel appointment.')
         return appt_id
@@ -358,7 +358,7 @@ class AppointmentsView(FlaskView):
             self.wcc.set_alert('success', 'Appointment Started Successfully!')
             return redirect(url_for('AppointmentsView:in_progress_appointment', appt_id=appt_id))
         except Exception as error:
-            self.wcc.set_alert('danger', 'Failed to start appointment: {0}'.format(error))
+            self.wcc.set_alert('danger', 'Failed to start appointment: {0}.'.format(error))
             return redirect(url_for('AppointmentsView:appointments_and_walk_ins'))
 
     @route('toggle-no-show/<int:appt_id>')
@@ -374,7 +374,7 @@ class AppointmentsView(FlaskView):
                 self.ac.revert_no_show(appt_id)
                 self.wcc.set_alert('success', '{0} {1} no longer marked as no show.'.format(student.firstName, student.lastName))
         except Exception as error:
-            self.wcc.set_alert('danger', 'Failed to toggle no show: {0}'.format(error))
+            self.wcc.set_alert('danger', 'Failed to toggle no show: {0}.'.format(error))
         return redirect(url_for('AppointmentsView:appointments_and_walk_ins'))
 
     @route('toggle-multilingual/<int:appt_id>')
@@ -389,7 +389,7 @@ class AppointmentsView(FlaskView):
                 self.ac.revert_multilingual(appt_id)
                 self.wcc.set_alert('success', '{0} {1}\'s appointment no longer marked as multilingual.'.format(student.firstName, student.lastName))
         except Exception as error:
-            self.wcc.set_alert('danger', 'Failed to toggle multilingual: {0}'.format(error))
+            self.wcc.set_alert('danger', 'Failed to toggle multilingual: {0}.'.format(error))
         return redirect(url_for('AppointmentsView:appointments_and_walk_ins'))
 
     @route('end-appt/<int:appt_id>', methods=['post', 'get'])
@@ -427,7 +427,7 @@ class AppointmentsView(FlaskView):
             self.wcc.set_alert('success', 'Appointment ended successfully!')
             return render_template('appointments/end_appointment.html', **locals())
         except Exception as error:
-            self.wcc.set_alert('danger', 'Failed to end appointment: {0}'.format(error))
+            self.wcc.set_alert('danger', 'Failed to end appointment: {0}.'.format(error))
             return redirect(url_for('AppointmentsView:in_progress_appointment', appt_id=appt_id))
 
     @route('in-progress/<int:appt_id>')
@@ -527,5 +527,5 @@ class AppointmentsView(FlaskView):
                               no_show, in_progress)
             self.wcc.set_alert('success', 'Appointment edited successfully!')
         except Exception as e:
-            self.wcc.set_alert('danger', 'Failed to edit appointment: ' + str(e))
+            self.wcc.set_alert('danger', 'Failed to edit appointment: {0}.'.format(str(e)))
         return redirect(url_for('AppointmentsView:edit', appt_id=appt_id))

--- a/writing_center/appointments/__init__.py
+++ b/writing_center/appointments/__init__.py
@@ -319,14 +319,17 @@ class AppointmentsView(FlaskView):
                                         break
                             # Schedules the appointment and sends an email to the student and tutor if it is scheduled
                             # successfully.
-                            appt = self.ac.schedule_appointment(appt_id, course, assignment)
-                            if appt:
-                                self.mcc.appointment_signup_student(appt_id)
-                                self.mcc.appointment_signup_tutor(appt_id)
-                                self.wcc.set_alert('success', 'Your Appointment Has Been Scheduled! To View Your '
-                                                              'Appointments, Go To The "View Your Appointments" Page!')
+                            if not self.ac.get_appointment_by_id(appt_id).student_id:
+                                appt = self.ac.schedule_appointment(appt_id, course, assignment)
+                                if appt:
+                                    self.mcc.appointment_signup_student(appt_id)
+                                    self.mcc.appointment_signup_tutor(appt_id)
+                                    self.wcc.set_alert('success', 'Your Appointment Has Been Scheduled! To View Your '
+                                                                  'Appointments, Go To The "View Your Appointments" Page!')
+                                else:
+                                    self.wcc.set_alert('danger', 'Error! Appointment Not Scheduled!')
                             else:
-                                self.wcc.set_alert('danger', 'Error! Appointment Not Scheduled!')
+                                self.wcc.set_alert('danger', 'Appointment has already been scheduled by someone else. Please try again.')
                     else:
                         self.wcc.set_alert('danger', 'Failed to schedule appointment. You already have ' + str(appt_limit) +
                                            ' appointments scheduled and can\'t schedule any more.')

--- a/writing_center/appointments/appointments_controller.py
+++ b/writing_center/appointments/appointments_controller.py
@@ -84,8 +84,11 @@ class AppointmentsController:
                 appointment.profName = course['instructor']
                 appointment.profEmail = course['instructor_email']
             # Commits to DB
-            db_session.commit()
-            return True
+            try:
+                db_session.commit()
+                return True
+            except Exception as e:
+                return False
 
     def cancel_appointment(self, appt_id):
         try:

--- a/writing_center/appointments/appointments_controller.py
+++ b/writing_center/appointments/appointments_controller.py
@@ -121,8 +121,11 @@ class AppointmentsController:
                                            actualStart=datetime.now(), assignment=assignment, inProgress=1, dropIn=1,
                                            sub=0, multilingual=multilingual, noShow=0)
         db_session.add(begin_appt)
-        db_session.commit()
-        return begin_appt
+        try:
+            db_session.commit()
+            return begin_appt
+        except Exception as e:
+            return False
 
     def get_scheduled_appointments(self, username):
         tutor = self.get_user_by_username(username)

--- a/writing_center/profile/__init__.py
+++ b/writing_center/profile/__init__.py
@@ -48,7 +48,7 @@ class ProfileView(FlaskView):
             flask_session.modified = True
             self.wcc.set_alert('success', 'Your profile has been edited successfully!')
         except Exception as error:
-            self.wcc.set_alert('danger', 'Failed to edit your profile: {0}'.format(str(error)))
+            self.wcc.set_alert('danger', 'Failed to edit your profile: {0}.'.format(str(error)))
         return redirect(url_for('ProfileView:index'))
 
     @route('/view-role')

--- a/writing_center/schedules/__init__.py
+++ b/writing_center/schedules/__init__.py
@@ -72,7 +72,7 @@ class SchedulesView(FlaskView):
                 self.sc.deactivate_time_slot(schedule_id)
             self.wcc.set_alert('success', 'Time slot(s) deactivated successfully!')
         except Exception as error:
-            self.wcc.set_alert('danger', 'Failed to deactivate time slot(s)')
+            self.wcc.set_alert('danger', 'Failed to deactivate time slot(s).')
         return 'done'  # Return doesn't matter: success or failure take you to the same page. Only the alert changes.
 
     @route('/add-tutors-to-shifts', methods=['POST'])
@@ -263,11 +263,11 @@ class SchedulesView(FlaskView):
         if appt_id == 'all':
             worked = self.sc.sub_all(appt_id_list)
             if not worked:
-                self.wcc.set_alert('danger', 'Failed to request a substitute for all appointments')
+                self.wcc.set_alert('danger', 'Failed to request a substitute for all appointments.')
         else:
             worked = self.sc.request_substitute(appt_id)
             if not worked:
-                self.wcc.set_alert('danger', 'Failed to request a substitute for appointment id {0}'.format(appt_id))
+                self.wcc.set_alert('danger', 'Failed to request a substitute for appointment id {0}.'.format(appt_id))
 
         return 'Substitute Requested Successfully'
 
@@ -379,7 +379,7 @@ class SchedulesView(FlaskView):
         self.wcc.check_roles_and_route(['Tutor', 'Administrator'])
 
         if flask_session['USERNAME'] in ['Administrator', 'Observer', 'Tutor', 'Student']:
-            self.wcc.set_alert('danger', 'You cannot pick up a shift while acting as a role')
+            self.wcc.set_alert('danger', 'You cannot pick up a shift while acting as a role.')
         else:
 
             appointment_id = str(json.loads(request.data).get('appt_id'))

--- a/writing_center/settings/__init__.py
+++ b/writing_center/settings/__init__.py
@@ -27,7 +27,7 @@ class SettingsView(FlaskView):
             self.wcc.set_alert('success', 'Settings updated successfully!')
             return 'success'
         except Exception as error:
-            self.wcc.set_alert('danger', 'Failed to update settings: {0}'.format(str(error)))
+            self.wcc.set_alert('danger', 'Failed to update settings: {0}.'.format(str(error)))
             return 'failed'
 
     @route('cleanse', methods=['get'])
@@ -37,5 +37,5 @@ class SettingsView(FlaskView):
             self.sc.cleanse()
             self.wcc.set_alert('success', 'System cleansed successfully!')
         except Exception as error:
-            self.wcc.set_alert('danger', 'Failed to cleanse system: {0}'.format(str(error)))
+            self.wcc.set_alert('danger', 'Failed to cleanse system: {0}.'.format(str(error)))
         return redirect(url_for('SettingsView:index'))

--- a/writing_center/users/__init__.py
+++ b/writing_center/users/__init__.py
@@ -102,7 +102,7 @@ class UsersView(FlaskView):
             self.wcc.set_alert('success', '{0} {1} ({2}) added successfully!'.format(first_name, last_name, username))
             return redirect(url_for('UsersView:view_all_users'))
         except Exception as error:
-            self.wcc.set_alert('danger', 'Failed to add user: {0}'.format(str(error)))
+            self.wcc.set_alert('danger', 'Failed to add user: {0}.'.format(str(error)))
             return redirect(url_for('UsersView:select_user_roles', username=username, first_name=first_name, last_name=last_name))
 
     @route("/edit/<int:user_id>")
@@ -129,7 +129,7 @@ class UsersView(FlaskView):
             self.wcc.set_alert('success', '{0} {1} edited successfully!'.format(first_name, last_name))
             return redirect(url_for('UsersView:view_all_users'))
         except Exception as error:
-            self.wcc.set_alert('danger', 'Failed to edit user: ' + str(error))
+            self.wcc.set_alert('danger', 'Failed to edit user: {0}.'.format(str(error)))
             return redirect(url_for('UsersView:edit_user', user_id=user_id))
 
     @route("/remove-ban/", methods=['POST'])
@@ -197,10 +197,10 @@ class UsersView(FlaskView):
                 flask_session.pop('ADMIN-NAME')
                 return redirect(url_for('View:index'))
             except Exception as error:
-                self.wcc.set_alert('danger', 'An error occurred: {0}'.format(str(error)))
+                self.wcc.set_alert('danger', 'An error occurred: {0}.'.format(str(error)))
                 return redirect(url_for('View:index'))
         else:
-            self.wcc.set_alert('danger', 'You do not have permission to access this function')
+            self.wcc.set_alert('danger', 'You do not have permission to access this function.')
             return redirect(url_for('View:index'))
 
     @route('/deactivate/<int:user_id>', methods=['POST', 'GET'])
@@ -210,7 +210,7 @@ class UsersView(FlaskView):
             self.wcc.set_alert('success', 'Users deactivated successfully!')
             return redirect(url_for("UsersView:view_all_users"))
         except Exception as e:
-            self.wcc.set_alert('danger', 'Failed to deactivate user(s)')
+            self.wcc.set_alert('danger', 'Failed to deactivate user(s).')
             return redirect(url_for("UsersView:edit", user_id=user_id))
 
     @route("/deactivate-users", methods=['post'])
@@ -223,5 +223,5 @@ class UsersView(FlaskView):
                 self.uc.deactivate_user(user)
             self.wcc.set_alert('success', 'User(s) deactivated successfully!')
         except Exception as error:
-            self.wcc.set_alert('danger', 'Failed to deactivate user(s): {0}'.format(str(error)))
+            self.wcc.set_alert('danger', 'Failed to deactivate user(s): {0}.'.format(str(error)))
         return 'done'  # Return doesn't matter: success or failure take you to the same page. Only the alert changes.


### PR DESCRIPTION
## Description

There was an issue where a tutor received an email with a student name, then clicked on the appointment and it was a different student who was actually signed up for the appointment.

My assumption on why this occurred was that when the two students signed up at the same time, one of them hit the db.commit() and it succeeded, but the other student hit the db.commit() and it that failed, but the method still returned true, so python thought the appointment was scheduled correctly which resulted in the email being sent to both the student and the tutor, but in fact the appointment was not scheduled.

I am hopefully solving this problem by adding a try catch around the db.commit() that only returns true if it succeeds and false otherwise.

## Size and Type of change

- Small Change - 1 person needs to review this
- Potential Bug fix

## How Has This Been Tested?

This hasn't been tested since I can't really re create the potential steps to cause this issue (schedule the same appointment at the same time as two different students)

## Checklist:

Only check what applies and what you have done.

- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have tested on multiple browsers (Chrome, Firefox, Safari, IE suite)
