### PR TITLE
Google Calendar Update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 config.py
+*gc_client_secret.json
+*token.pickle
 *.pyc
 .DS_Store
 .idea*

--- a/config.py.dist
+++ b/config.py.dist
@@ -6,6 +6,8 @@ SECRET_KEY = ""
 
 SENTRY_URL = ""
 
+GC_CLIENT_SECRET = ""
+
 ENVIRON = ""
 
 DATABASE_KEY = ""

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,6 @@ Flask-SQLAlchemy
 SQLAlchemy-migrate
 mysqlclient
 Flask-Mail
+google-api-python-client
+google-auth-httplib2
+google-auth-oauthlib

--- a/writing_center/__init__.py
+++ b/writing_center/__init__.py
@@ -16,9 +16,6 @@ if app.config['ENVIRON'] == 'prod' and app.config['SENTRY_URL']:
     sentry_sdk.init(dsn=app.config['SENTRY_URL'], integrations=[FlaskIntegration()])
     from writing_center import error
 
-if app.config['ENVIRON'] == 'prod' or app.config['ENVIRON'] == 'xp':
-    logging.getLogger('googleapiclient.discovery_cache').setLevel(logging.ERROR)
-
 # Declaring and registering the views
 from writing_center.views import View
 from writing_center.message_center import MessageCenterView

--- a/writing_center/__init__.py
+++ b/writing_center/__init__.py
@@ -26,6 +26,7 @@ from writing_center.schedules import SchedulesView
 from writing_center.settings import SettingsView
 from writing_center.statistics import StatisticsView
 from writing_center.users import UsersView
+from writing_center.google_calendar import GoogleCalendarView
 from writing_center.users.users_controller import UsersController as uc
 from writing_center.writing_center_controller import WritingCenterController as wcc
 
@@ -38,6 +39,7 @@ SchedulesView.register(app)
 SettingsView.register(app)
 StatisticsView.register(app)
 UsersView.register(app)
+GoogleCalendarView.register(app)
 
 
 # This makes these variables open to use everywhere

--- a/writing_center/__init__.py
+++ b/writing_center/__init__.py
@@ -16,6 +16,9 @@ if app.config['ENVIRON'] == 'prod' and app.config['SENTRY_URL']:
     sentry_sdk.init(dsn=app.config['SENTRY_URL'], integrations=[FlaskIntegration()])
     from writing_center import error
 
+if app.config['ENVIRON'] == 'prod' or app.config['ENVIRON'] == 'xp':
+    logging.getLogger('googleapiclient.discovery_cache').setLevel(logging.ERROR)
+
 # Declaring and registering the views
 from writing_center.views import View
 from writing_center.message_center import MessageCenterView

--- a/writing_center/appointments/__init__.py
+++ b/writing_center/appointments/__init__.py
@@ -36,6 +36,7 @@ class AppointmentsView(FlaskView):
         cancel = json.loads(request.data).get('cancel')
         pickup_sub_delete = json.loads(request.data).get('subDelete')
         tutor_edit = json.loads(request.data).get('tutorEdit')
+        add_google_calendar = json.loads(request.data).get('gcalAdd', None)
         if 'Tutor' not in flask_session['USER-ROLES']:
             tutor_edit = False
         appointment = self.ac.get_appointment_by_id(appt_id)

--- a/writing_center/error.py
+++ b/writing_center/error.py
@@ -8,6 +8,7 @@ from flask import session as flask_session
 from writing_center import app, sentry_sdk
 from sentry_sdk import configure_scope
 
+
 def error_render_template(template, error, code=None):
 
     # Check to make sure ALERT has been set, otherwise the template will fail to load

--- a/writing_center/google_calendar/__init__.py
+++ b/writing_center/google_calendar/__init__.py
@@ -1,0 +1,28 @@
+from flask_classy import route, FlaskView, request
+from flask import json
+from flask import session as flask_session
+
+
+from writing_center.google_calendar.google_calendar_controller import GoogleCalendarController
+
+
+class GoogleCalendarView(FlaskView):
+
+    def __init__(self):
+        self.gcc = GoogleCalendarController()
+
+    @route("/add-google-calendar-event", methods=['POST'])
+    def add_event_to_google_calendar(self):
+        appt_id = str(json.loads(request.data).get('appt_id'))
+
+        self.gcc.handle_event(appt_id)
+
+        return ''
+
+    @route("/add-google-calendar-events", methods=['POST'])
+    def add_events_to_google_calendar(self):
+        user = self.gcc.get_user_by_username(flask_session['USERNAME'])
+
+        self.gcc.handle_events(user)
+
+        return ''

--- a/writing_center/google_calendar/__init__.py
+++ b/writing_center/google_calendar/__init__.py
@@ -1,5 +1,5 @@
 from flask_classy import route, FlaskView, request
-from flask import json, url_for, redirect, jsonify
+from flask import json, url_for, redirect
 from flask import session as flask_session
 from google.oauth2.credentials import Credentials
 import google_auth_oauthlib.flow
@@ -35,11 +35,10 @@ class GoogleCalendarView(FlaskView):
 
         authorization_url, state = flow.authorization_url(
             # Enable offline access so that you can refresh an access token without
-            # re-prompting the user for permission. Recommended for web server apps.
+            # re-prompting the user for permission.
             access_type='offline',
             login_hint=user.email,
             prompt='consent',
-            # Enable incremental authorization. Recommended as a best practice.
             include_granted_scopes='true')
 
         # Store the state so the callback can verify the auth server response.
@@ -115,11 +114,10 @@ class GoogleCalendarView(FlaskView):
 
         authorization_url, state = flow.authorization_url(
             # Enable offline access so that you can refresh an access token without
-            # re-prompting the user for permission. Recommended for web server apps.
+            # re-prompting the user for permission.
             access_type='offline',
             login_hint=user.email,
             prompt='consent',
-            # Enable incremental authorization. Recommended as a best practice.
             include_granted_scopes='true')
 
         # Store the state so the callback can verify the auth server response.
@@ -145,8 +143,6 @@ class GoogleCalendarView(FlaskView):
         flow.fetch_token(authorization_response=authorization_response)
 
         # Store credentials in the session.
-        # ACTION ITEM: In a production app, you likely want to save these
-        #              credentials in a persistent database instead.
         credentials = flow.credentials
         flask_session['CREDENTIALS'] = self.gcc.credentials_to_dict(credentials)
 

--- a/writing_center/google_calendar/__init__.py
+++ b/writing_center/google_calendar/__init__.py
@@ -159,12 +159,10 @@ class GoogleCalendarView(FlaskView):
         flask_session['CREDENTIALS'] = self.gcc.credentials_to_dict(credentials)
 
         global login_page
-        if login_page == 'student':
-            return redirect(url_for('AppointmentsView:student_view_appointments'))
-        elif login_page == 'tutor':
+        if login_page == 'tutor':
             return redirect(url_for('SchedulesView:view_tutor_schedules'))
         else:
-            return ''
+            return redirect(url_for('AppointmentsView:student_view_appointments'))
 
 
 

--- a/writing_center/google_calendar/__init__.py
+++ b/writing_center/google_calendar/__init__.py
@@ -36,7 +36,7 @@ class GoogleCalendarView(FlaskView):
         authorization_url, state = flow.authorization_url(
             # Enable offline access so that you can refresh an access token without
             # re-prompting the user for permission. Recommended for web server apps.
-            access_type='offline',
+            access_type='online',
             login_hint=user.email,
             prompt='consent',
             # Enable incremental authorization. Recommended as a best practice.
@@ -119,7 +119,7 @@ class GoogleCalendarView(FlaskView):
         authorization_url, state = flow.authorization_url(
             # Enable offline access so that you can refresh an access token without
             # re-prompting the user for permission. Recommended for web server apps.
-            access_type='offline',
+            access_type='online',
             login_hint=user.email,
             prompt='consent',
             # Enable incremental authorization. Recommended as a best practice.

--- a/writing_center/google_calendar/__init__.py
+++ b/writing_center/google_calendar/__init__.py
@@ -52,7 +52,7 @@ class GoogleCalendarView(FlaskView):
         credentials = Credentials(
             **flask_session['CREDENTIALS'])
 
-        service = build('calendar', 'v3', credentials=credentials)
+        service = build('calendar', 'v3', credentials=credentials, cache_discovery=True, cache=None)
 
         appt_id = str(json.loads(request.data).get('appt_id'))
 

--- a/writing_center/google_calendar/__init__.py
+++ b/writing_center/google_calendar/__init__.py
@@ -94,8 +94,6 @@ class GoogleCalendarView(FlaskView):
         calendar_service = build('calendar', 'v3', credentials=credentials, cache_discovery=False)
 
         # Save credentials back to session in case access token was refreshed.
-        # ACTION ITEM: In a production app, you likely want to save these
-        #              credentials in a persistent database instead.
         flask_session['CREDENTIALS'] = self.gcc.credentials_to_dict(credentials)
 
         return 'cat'

--- a/writing_center/google_calendar/__init__.py
+++ b/writing_center/google_calendar/__init__.py
@@ -93,7 +93,6 @@ class GoogleCalendarView(FlaskView):
         global calendar_service
         calendar_service = build('calendar', 'v3', credentials=credentials, cache_discovery=False)
 
-
         # Save credentials back to session in case access token was refreshed.
         # ACTION ITEM: In a production app, you likely want to save these
         #              credentials in a persistent database instead.

--- a/writing_center/google_calendar/__init__.py
+++ b/writing_center/google_calendar/__init__.py
@@ -36,7 +36,7 @@ class GoogleCalendarView(FlaskView):
         authorization_url, state = flow.authorization_url(
             # Enable offline access so that you can refresh an access token without
             # re-prompting the user for permission. Recommended for web server apps.
-            access_type='online',
+            access_type='offline',
             login_hint=user.email,
             prompt='consent',
             # Enable incremental authorization. Recommended as a best practice.
@@ -119,7 +119,7 @@ class GoogleCalendarView(FlaskView):
         authorization_url, state = flow.authorization_url(
             # Enable offline access so that you can refresh an access token without
             # re-prompting the user for permission. Recommended for web server apps.
-            access_type='online',
+            access_type='offline',
             login_hint=user.email,
             prompt='consent',
             # Enable incremental authorization. Recommended as a best practice.

--- a/writing_center/google_calendar/__init__.py
+++ b/writing_center/google_calendar/__init__.py
@@ -1,28 +1,170 @@
 from flask_classy import route, FlaskView, request
-from flask import json
+from flask import json, url_for, redirect, jsonify
 from flask import session as flask_session
-
+from google.oauth2.credentials import Credentials
+import google_auth_oauthlib.flow
+from googleapiclient.discovery import build
 
 from writing_center.google_calendar.google_calendar_controller import GoogleCalendarController
 
 
 class GoogleCalendarView(FlaskView):
+    route_base = '/google-calendar'
+
+    global login_page
+    login_page = None
 
     def __init__(self):
         self.gcc = GoogleCalendarController()
 
+    def index(self):
+        return 'cat'
+
+    @route('login-to-google-calendar', methods=['POST'])
+    def login_to_google_calendar(self):
+        global login_page
+        login_page = str(json.loads(request.data).get('page_type'))
+
+        scopes = ['https://www.googleapis.com/auth/calendar.events']
+        user = self.gcc.get_user_by_username(flask_session['USERNAME'])
+
+        # Create flow instance to manage the OAuth 2.0 Authorization Grant Flow steps.
+        flow = google_auth_oauthlib.flow.Flow.from_client_secrets_file(
+            'gc_client_secret.json', scopes=scopes)
+
+        # The URI created here must exactly match one of the authorized redirect URIs
+        # for the OAuth 2.0 client, which you configured in the API Console. If this
+        # value doesn't match an authorized URI, you will get a 'redirect_uri_mismatch'
+        # error.
+        flow.redirect_uri = url_for('GoogleCalendarView:oauth2callback', _external=True)
+
+        authorization_url, state = flow.authorization_url(
+            # Enable offline access so that you can refresh an access token without
+            # re-prompting the user for permission. Recommended for web server apps.
+            access_type='offline',
+            login_hint=user.email,
+            prompt='consent',
+            # Enable incremental authorization. Recommended as a best practice.
+            include_granted_scopes='true')
+
+        # Store the state so the callback can verify the auth server response.
+        flask_session['STATE'] = state
+
+        return authorization_url
+
     @route("/add-google-calendar-event", methods=['POST'])
     def add_event_to_google_calendar(self):
+        # Load credentials from the session.
+        credentials = Credentials(
+            **flask_session['CREDENTIALS'])
+
+        service = build('calendar', 'v3', credentials=credentials)
+
         appt_id = str(json.loads(request.data).get('appt_id'))
 
-        self.gcc.handle_event(appt_id)
+        self.gcc.handle_event(appt_id, service)
 
         return ''
 
     @route("/add-google-calendar-events", methods=['POST'])
     def add_events_to_google_calendar(self):
+        # Load credentials from the session.
+        credentials = Credentials(
+            **flask_session['CREDENTIALS'])
+
+        service = build('calendar', 'v3', credentials=credentials)
+
         user = self.gcc.get_user_by_username(flask_session['USERNAME'])
 
-        self.gcc.handle_events(user)
+        page_type = str(json.loads(request.data).get('page_type'))
+
+        self.gcc.handle_events(user, page_type, service)
 
         return ''
+
+    @route('/test')
+    def test_api_request(self):
+        if 'credentials' in flask_session:
+            flask_session.pop("credentials")
+        if 'CREDENTIALS' in flask_session:
+            flask_session.pop("CREDENTIALS")
+        if 'CREDENTIALS' not in flask_session:
+            return redirect('authorize')
+
+        # Load credentials from the session.
+        credentials = Credentials(
+            **flask_session['CREDENTIALS'])
+
+        global calendar_service
+        calendar_service = build('calendar', 'v3', credentials=credentials)
+
+
+        # Save credentials back to session in case access token was refreshed.
+        # ACTION ITEM: In a production app, you likely want to save these
+        #              credentials in a persistent database instead.
+        flask_session['CREDENTIALS'] = self.gcc.credentials_to_dict(credentials)
+
+        return 'cat'
+
+    @route('/authorize')
+    def authorize(self):
+        scopes = ['https://www.googleapis.com/auth/calendar.events']
+        user = self.gcc.get_user_by_username(flask_session['USERNAME'])
+
+        # Create flow instance to manage the OAuth 2.0 Authorization Grant Flow steps.
+        flow = google_auth_oauthlib.flow.Flow.from_client_secrets_file(
+            'gc_client_secret.json', scopes=scopes)
+
+        # The URI created here must exactly match one of the authorized redirect URIs
+        # for the OAuth 2.0 client, which you configured in the API Console. If this
+        # value doesn't match an authorized URI, you will get a 'redirect_uri_mismatch'
+        # error.
+        flow.redirect_uri = url_for('GoogleCalendarView:oauth2callback', _external=True)
+
+        authorization_url, state = flow.authorization_url(
+            # Enable offline access so that you can refresh an access token without
+            # re-prompting the user for permission. Recommended for web server apps.
+            access_type='offline',
+            login_hint=user.email,
+            prompt='consent',
+            # Enable incremental authorization. Recommended as a best practice.
+            include_granted_scopes='true')
+
+        # Store the state so the callback can verify the auth server response.
+        flask_session['STATE'] = state
+
+        return redirect(authorization_url)
+
+    def oauth2callback(self):
+        scopes = ['https://www.googleapis.com/auth/calendar.events']
+        # Specify the state when creating the flow in the callback so that it can
+        # verified in the authorization server response.
+        state = flask_session['STATE']
+
+        flow = google_auth_oauthlib.flow.Flow.from_client_secrets_file(
+            'gc_client_secret.json',
+            scopes=scopes,
+            state=state)
+        flow.redirect_uri = url_for('GoogleCalendarView:oauth2callback', _external=True)
+
+        # Use the authorization server's response to fetch the OAuth 2.0 tokens.
+        authorization_response = request.url
+
+        flow.fetch_token(authorization_response=authorization_response)
+
+        # Store credentials in the session.
+        # ACTION ITEM: In a production app, you likely want to save these
+        #              credentials in a persistent database instead.
+        credentials = flow.credentials
+        flask_session['CREDENTIALS'] = self.gcc.credentials_to_dict(credentials)
+
+        global login_page
+        if login_page == 'student':
+            return redirect(url_for('AppointmentsView:student_view_appointments'))
+        elif login_page == 'tutor':
+            return redirect(url_for('SchedulesView:view_tutor_schedules'))
+        else:
+            return ''
+
+
+

--- a/writing_center/google_calendar/__init__.py
+++ b/writing_center/google_calendar/__init__.py
@@ -76,27 +76,6 @@ class GoogleCalendarView(FlaskView):
 
         return ''
 
-    @route('/test')
-    def test_api_request(self):
-        if 'credentials' in flask_session:
-            flask_session.pop("credentials")
-        if 'CREDENTIALS' in flask_session:
-            flask_session.pop("CREDENTIALS")
-        if 'CREDENTIALS' not in flask_session:
-            return redirect('authorize')
-
-        # Load credentials from the session.
-        credentials = Credentials(
-            **flask_session['CREDENTIALS'])
-
-        global calendar_service
-        calendar_service = build('calendar', 'v3', credentials=credentials, cache_discovery=False)
-
-        # Save credentials back to session in case access token was refreshed.
-        flask_session['CREDENTIALS'] = self.gcc.credentials_to_dict(credentials)
-
-        return 'cat'
-
     @route('/authorize')
     def authorize(self):
         scopes = ['https://www.googleapis.com/auth/calendar.events']

--- a/writing_center/google_calendar/__init__.py
+++ b/writing_center/google_calendar/__init__.py
@@ -58,7 +58,7 @@ class GoogleCalendarView(FlaskView):
 
         self.gcc.handle_event(appt_id, service)
 
-        return ''
+        return 'success'
 
     @route("/add-google-calendar-events", methods=['POST'])
     def add_events_to_google_calendar(self):
@@ -74,7 +74,7 @@ class GoogleCalendarView(FlaskView):
 
         self.gcc.handle_events(user, page_type, service)
 
-        return ''
+        return 'success'
 
     @route('/authorize')
     def authorize(self):

--- a/writing_center/google_calendar/__init__.py
+++ b/writing_center/google_calendar/__init__.py
@@ -52,7 +52,7 @@ class GoogleCalendarView(FlaskView):
         credentials = Credentials(
             **flask_session['CREDENTIALS'])
 
-        service = build('calendar', 'v3', credentials=credentials, cache_discovery=True, cache=None)
+        service = build('calendar', 'v3', credentials=credentials)
 
         appt_id = str(json.loads(request.data).get('appt_id'))
 

--- a/writing_center/google_calendar/__init__.py
+++ b/writing_center/google_calendar/__init__.py
@@ -17,9 +17,6 @@ class GoogleCalendarView(FlaskView):
     def __init__(self):
         self.gcc = GoogleCalendarController()
 
-    def index(self):
-        return 'cat'
-
     @route('login-to-google-calendar', methods=['POST'])
     def login_to_google_calendar(self):
         global login_page

--- a/writing_center/google_calendar/__init__.py
+++ b/writing_center/google_calendar/__init__.py
@@ -5,6 +5,7 @@ from google.oauth2.credentials import Credentials
 import google_auth_oauthlib.flow
 from googleapiclient.discovery import build
 
+from writing_center import app
 from writing_center.google_calendar.google_calendar_controller import GoogleCalendarController
 
 
@@ -24,7 +25,7 @@ class GoogleCalendarView(FlaskView):
 
         # Create flow instance to manage the OAuth 2.0 Authorization Grant Flow steps.
         flow = google_auth_oauthlib.flow.Flow.from_client_secrets_file(
-            'gc_client_secret.json', scopes=scopes)
+            app.config['GC_CLIENT_SECRET'], scopes=scopes)
 
         # The URI created here must exactly match one of the authorized redirect URIs
         # for the OAuth 2.0 client, which you configured in the API Console. If this
@@ -107,7 +108,7 @@ class GoogleCalendarView(FlaskView):
 
         # Create flow instance to manage the OAuth 2.0 Authorization Grant Flow steps.
         flow = google_auth_oauthlib.flow.Flow.from_client_secrets_file(
-            'gc_client_secret.json', scopes=scopes)
+            app.config['GC_CLIENT_SECRET'], scopes=scopes)
 
         # The URI created here must exactly match one of the authorized redirect URIs
         # for the OAuth 2.0 client, which you configured in the API Console. If this
@@ -136,7 +137,7 @@ class GoogleCalendarView(FlaskView):
         state = flask_session['STATE']
 
         flow = google_auth_oauthlib.flow.Flow.from_client_secrets_file(
-            'gc_client_secret.json',
+            app.config['GC_CLIENT_SECRET'],
             scopes=scopes,
             state=state)
         flow.redirect_uri = url_for('GoogleCalendarView:oauth2callback', _external=True)

--- a/writing_center/google_calendar/__init__.py
+++ b/writing_center/google_calendar/__init__.py
@@ -11,16 +11,13 @@ from writing_center.google_calendar.google_calendar_controller import GoogleCale
 class GoogleCalendarView(FlaskView):
     route_base = '/google-calendar'
 
-    global login_page
-    login_page = None
-
     def __init__(self):
         self.gcc = GoogleCalendarController()
 
     @route('login-to-google-calendar', methods=['POST'])
     def login_to_google_calendar(self):
-        global login_page
         login_page = str(json.loads(request.data).get('page_type'))
+        flask_session['LOGIN-PAGE'] = login_page
 
         scopes = ['https://www.googleapis.com/auth/calendar.events']
         user = self.gcc.get_user_by_username(flask_session['USERNAME'])
@@ -155,11 +152,13 @@ class GoogleCalendarView(FlaskView):
         credentials = flow.credentials
         flask_session['CREDENTIALS'] = self.gcc.credentials_to_dict(credentials)
 
-        global login_page
+        login_page = flask_session['LOGIN-PAGE']
         if login_page == 'tutor':
             return redirect(url_for('SchedulesView:view_tutor_schedules'))
-        else:
+        elif login_page == 'student':
             return redirect(url_for('AppointmentsView:student_view_appointments'))
+        else:
+            return redirect(url_for('View:index'))
 
 
 

--- a/writing_center/google_calendar/__init__.py
+++ b/writing_center/google_calendar/__init__.py
@@ -53,7 +53,7 @@ class GoogleCalendarView(FlaskView):
         credentials = Credentials(
             **flask_session['CREDENTIALS'])
 
-        service = build('calendar', 'v3', credentials=credentials)
+        service = build('calendar', 'v3', credentials=credentials, cache_discovery=False)
 
         appt_id = str(json.loads(request.data).get('appt_id'))
 
@@ -67,7 +67,7 @@ class GoogleCalendarView(FlaskView):
         credentials = Credentials(
             **flask_session['CREDENTIALS'])
 
-        service = build('calendar', 'v3', credentials=credentials)
+        service = build('calendar', 'v3', credentials=credentials, cache_discovery=False)
 
         user = self.gcc.get_user_by_username(flask_session['USERNAME'])
 
@@ -91,7 +91,7 @@ class GoogleCalendarView(FlaskView):
             **flask_session['CREDENTIALS'])
 
         global calendar_service
-        calendar_service = build('calendar', 'v3', credentials=credentials)
+        calendar_service = build('calendar', 'v3', credentials=credentials, cache_discovery=False)
 
 
         # Save credentials back to session in case access token was refreshed.

--- a/writing_center/google_calendar/google_calendar_controller.py
+++ b/writing_center/google_calendar/google_calendar_controller.py
@@ -34,11 +34,11 @@ class GoogleCalendarController:
         exists = False
         for event in events:
             try:
-                if int(event['id']) == appt_id:
+                if int(event['id'].replace('appt', '')) == appt_id:
                     event['status'] = 'confirmed'
                     event['start']['dateTime'] = start_time.strftime('%Y-%m-%dT%H:%M:%S')
                     event['end']['dateTime'] = end_time.strftime('%Y-%m-%dT%H:%M:%S')
-                    event = service.events().update(calendarId='primary', body=event, eventId=appt_id).execute()
+                    event = service.events().update(calendarId='primary', body=event, eventId=event['id']).execute()
                     exists = True
             except:
                 pass
@@ -46,8 +46,10 @@ class GoogleCalendarController:
         if not exists:
             timezone = 'America/Chicago'
 
+            event_id = 'appt' + str(appt_id)
+
             event = {
-                'id': appt_id,
+                'id': event_id,
                 'summary': 'Writing Center Appointment',
                 'location': 'Bethel University',
                 'start': {

--- a/writing_center/google_calendar/google_calendar_controller.py
+++ b/writing_center/google_calendar/google_calendar_controller.py
@@ -27,13 +27,12 @@ class GoogleCalendarController:
     def create_event(self, appt_id, start_time, end_time, service):
         query = "Writing Center Appointment"
         events = service.events().list(calendarId='primary', q=query, singleEvents='True', orderBy='startTime',
-                                       timeMin=start_time.strftime('%Y-%m-%dT%H:%M:%S-06:00'),
-                                       timeMax=end_time.strftime('%Y-%m-%dT%H:%M:%S-06:00'), showDeleted=True).execute()
+                                       timeMin=datetime.now().strftime('%Y-%m-%dT%H:%M:%S-06:00'),
+                                       showDeleted=True).execute()
         events = events.get('items')
 
         exists = False
         for event in events:
-
             try:
                 if int(event['id']) == appt_id:
                     event['status'] = 'confirmed'
@@ -71,7 +70,8 @@ class GoogleCalendarController:
 
             try:
                 event = service.events().insert(calendarId='primary', body=event).execute()
-            except:
+            except Exception as e:
+                print(e)
                 pass
 
     def get_appointment_by_id(self, appt_id):

--- a/writing_center/google_calendar/google_calendar_controller.py
+++ b/writing_center/google_calendar/google_calendar_controller.py
@@ -1,0 +1,120 @@
+from __future__ import print_function
+import pickle
+import os.path
+from google_auth_oauthlib.flow import InstalledAppFlow
+from google.auth.transport.requests import Request
+from googleapiclient.discovery import build
+from datetime import datetime
+
+
+from writing_center.db_repository import db_session
+from writing_center.db_repository.tables import UserTable, AppointmentsTable
+
+
+class GoogleCalendarController:
+    def __init__(self):
+        pass
+
+    def get_calendar_service(self):
+        scopes = ['https://www.googleapis.com/auth/calendar.events']
+
+        creds = None
+        # The file token.pickle stores the user's access and refresh tokens, and is
+        # created automatically when the authorization flow completes for the first
+        # time.
+
+        if os.path.exists('token.pickle'):
+            with open('token.pickle', 'rb') as token:
+                creds = pickle.load(token)
+        # If there are no (valid) credentials available, let the user log in.
+
+        if not creds or not creds.valid:
+            if creds and creds.expired and creds.refresh_token:
+                creds.refresh(Request())
+            else:
+                flow = InstalledAppFlow.from_client_secrets_file(
+                    'gc_client_secret.json', scopes)
+                creds = flow.run_local_server(port=0)
+            # Save the credentials for the next run
+            with open('token.pickle', 'wb') as token:
+                pickle.dump(creds, token)
+
+        service = build('calendar', 'v3', credentials=creds)
+
+        return service
+
+    def handle_event(self, appt_id):
+        service = self.get_calendar_service()
+
+        appt = self.get_appointment_by_id(appt_id)
+        start_time = appt.scheduledStart
+        end_time = appt.scheduledEnd
+
+        self.create_event(appt.id, start_time, end_time, service)
+
+    def handle_events(self, user):
+        service = self.get_calendar_service()
+
+        future_appts = self.get_future_user_appointments(user.id)
+
+        for appt in future_appts:
+            self.create_event(appt.id, appt.scheduledStart, appt.scheduledEnd, service)
+
+    def create_event(self, appt_id, start_time, end_time, service):
+        query = "Writing Center Appointment"
+        events = service.events().list(calendarId='primary', q=query, singleEvents='True', orderBy='startTime',
+                                       timeMin=start_time.strftime('%Y-%m-%dT%H:%M:%S-06:00'),
+                                       timeMax=end_time.strftime('%Y-%m-%dT%H:%M:%S-06:00')).execute()
+        events = events.get('items')
+
+        if events:
+            try:
+                event = service.events().delete(calendarId='primary', eventId=appt_id).execute()
+            except:
+                pass
+
+        timezone = 'America/Chicago'
+
+        event = {
+            'id': appt_id,
+            'summary': 'Writing Center Appointment',
+            'location': 'Bethel University',
+            'start': {
+                'dateTime': start_time.strftime('%Y-%m-%dT%H:%M:%S'),
+                'timeZone': timezone,
+            },
+            'end': {
+                'dateTime': end_time.strftime('%Y-%m-%dT%H:%M:%S'),
+                'timeZone': timezone,
+            },
+            'reminders': {
+                'useDefault': False,
+                'overrides': [
+                    {'method': 'email', 'minutes': 24 * 60},
+                    {'method': 'popup', 'minutes': 10},
+                ],
+            },
+            'Content-Type': 'application/json;charset=UTF-8',
+        }
+
+        try:
+            event = service.events().insert(calendarId='primary', body=event).execute()
+        except Exception as e:
+            event = service.events().update(calendarId='primary', body=event, eventId=appt_id).execute()
+
+    def get_appointment_by_id(self, appt_id):
+        return db_session.query(AppointmentsTable)\
+            .filter(AppointmentsTable.id == appt_id)\
+            .one_or_none()
+
+    def get_future_user_appointments(self, user_id):
+        return db_session.query(AppointmentsTable)\
+            .filter(AppointmentsTable.student_id == user_id)\
+            .filter(AppointmentsTable.scheduledStart > datetime.now())\
+            .all()
+
+    def get_user_by_username(self, username):
+        return db_session.query(UserTable)\
+            .filter(UserTable.username == username)\
+            .one_or_none()
+

--- a/writing_center/profile/__init__.py
+++ b/writing_center/profile/__init__.py
@@ -1,7 +1,6 @@
 from flask_classy import FlaskView, route
 from flask import render_template, request, redirect, url_for
 from flask import session as flask_session
-import json
 
 from writing_center.profile.profile_controller import ProfileController
 from writing_center.writing_center_controller import WritingCenterController

--- a/writing_center/templates/appointments/student_view_appointments.html
+++ b/writing_center/templates/appointments/student_view_appointments.html
@@ -7,6 +7,7 @@
         <h1><b>Scheduled Appointments</b></h1>
         <p>View or cancel your scheduled appointments here.</p>
     </div>
+    {{ gcal_macros.add_events_to_calendar("Add Upcoming Appointments To Google Calendar") }}
     <div id="results"></div>
     <hr>
     <div id="calendar"></div>

--- a/writing_center/templates/appointments/student_view_appointments.html
+++ b/writing_center/templates/appointments/student_view_appointments.html
@@ -7,7 +7,7 @@
         <h1><b>Scheduled Appointments</b></h1>
         <p>View or cancel your scheduled appointments here.</p>
     </div>
-    {{ gcal_macros.add_events_to_calendar("Add Upcoming Appointments To Google Calendar") }}
+    {{ gcal_macros.add_events_to_calendar("Add All Upcoming Appointments To Google Calendar") }}
     <div id="results"></div>
     <hr>
     <div id="calendar"></div>
@@ -52,7 +52,8 @@
                         url: "{{ url_for('AppointmentsView:load_appointment_data') }}",
                         data: JSON.stringify({
                             'id': info.event.id,
-                            'cancel': true
+                            'cancel': true,
+                            'gcalAdd': 'student',
                         }),
                         contentType: 'application/json;charset=UTF-8',
                         success: function (response) {

--- a/writing_center/templates/appointments/student_view_appointments.html
+++ b/writing_center/templates/appointments/student_view_appointments.html
@@ -7,7 +7,11 @@
         <h1><b>Scheduled Appointments</b></h1>
         <p>View or cancel your scheduled appointments here.</p>
     </div>
-    {{ gcal_macros.add_events_to_calendar("Add All Upcoming Appointments To Google Calendar") }}
+    {% if 'CREDENTIALS' in session %}
+        {{ gcal_events.add_events_to_calendar("Add All Upcoming Appointments To Google Calendar") }}
+    {% else %}
+        {{ gcal_login.login_to_google_calendar() }}
+    {% endif %}
     <div id="results"></div>
     <hr>
     <div id="calendar"></div>

--- a/writing_center/templates/macros/add-events-to-calendar.html
+++ b/writing_center/templates/macros/add-events-to-calendar.html
@@ -1,0 +1,19 @@
+{% macro add_events_to_calendar(button_text) %}
+    <div class="form-row">
+        <button id="add-events-to-gcal" class="btn btn-primary darkblue"><i class="far fa-calendar-alt"></i> {{ button_text }}</button>
+    </div>
+    <script type="text/javascript">
+        $('#add-events-to-gcal').click(function() {
+            $.ajax({
+                type: "POST",
+                url: "{{ url_for('GoogleCalendarView:add_events_to_google_calendar') }}",
+                contentType: 'application/json;charset=UTF-8',
+                success: function (response) {
+                    $('#add-events-to-gcal').html("Successfully added!");
+                },
+                error: function (error) {
+                }
+            });
+        });
+    </script>
+{% endmacro %}

--- a/writing_center/templates/macros/add-events-to-calendar.html
+++ b/writing_center/templates/macros/add-events-to-calendar.html
@@ -1,17 +1,42 @@
 {% macro add_events_to_calendar(button_text) %}
     <div class="form-row">
-        <button id="add-events-to-gcal" class="btn btn-primary darkblue"><i class="far fa-calendar-alt"></i> {{ button_text }}</button>
+        <input id="page-type" type="hidden" value="{% if "Appointments" in button_text %}student{% else %}tutor{% endif %}" />
+        <button id="{% if "CREDENTIALS" in session %}add-events-to-gcal{% else %}login-to-gcal{% endif %}" class="btn btn-primary darkblue"><i class="far fa-calendar-alt"></i>
+            {% if "CREDENTIALS" in session %}{{ button_text }}{% else %}Login To Add All {% if "Appointments" in button_text %}Appointments{% else %}Shifts{% endif %} To Google Calendar{% endif %}
+        </button>
     </div>
     <script type="text/javascript">
         $('#add-events-to-gcal').click(function() {
+            let page_type = $("#page-type").val();
             $.ajax({
                 type: "POST",
                 url: "{{ url_for('GoogleCalendarView:add_events_to_google_calendar') }}",
                 contentType: 'application/json;charset=UTF-8',
+                data: JSON.stringify({
+                    'page_type': page_type
+                }),
                 success: function (response) {
                     $('#add-events-to-gcal').html("Successfully added!");
                 },
                 error: function (error) {
+                }
+            });
+        });
+
+        $('#login-to-gcal').click(function() {
+            let page_type = $("#page-type").val();
+            $.ajax({
+                type: "POST",
+                url: "{{ url_for('GoogleCalendarView:login_to_google_calendar') }}",
+                data: JSON.stringify({
+                    'page_type': page_type
+                }),
+                contentType: 'application/json;charset=UTF-8',
+                success: function (response) {
+                    window.location.replace(response);
+                },
+                error: function (error) {
+
                 }
             });
         });

--- a/writing_center/templates/macros/add-events-to-calendar.html
+++ b/writing_center/templates/macros/add-events-to-calendar.html
@@ -2,7 +2,7 @@
     <div class="form-row">
         <input id="page-type" type="hidden" value="{% if "Appointments" in button_text %}student{% else %}tutor{% endif %}" />
         <button id="{% if "CREDENTIALS" in session %}add-events-to-gcal{% else %}login-to-gcal{% endif %}" class="btn btn-primary darkblue"><i class="far fa-calendar-alt"></i>
-            {% if "CREDENTIALS" in session %}{{ button_text }}{% else %}Login To Add All {% if "Appointments" in button_text %}Appointments{% else %}Shifts{% endif %} To Google Calendar{% endif %}
+            {% if "CREDENTIALS" in session %}{{ button_text }}{% else %}Login To Add {% if "Appointments" in button_text %}Appointments{% else %}Shifts{% endif %} To Your Google Calendar{% endif %}
         </button>
     </div>
     <script type="text/javascript">

--- a/writing_center/templates/macros/appointment_modal.html
+++ b/writing_center/templates/macros/appointment_modal.html
@@ -6,6 +6,7 @@
                 <button type="button" class="close" data-dismiss="modal" aria-label="Close">
                     <span aria-hidden="true">&times;</span>
                 </button>
+                <input id="appt-id" value="{{ appt_id }}" type="hidden" />
             </div>
             <div class="modal-body">
                 <table id="modal-table" class="table table-striped table-bordered">
@@ -158,6 +159,13 @@
                             </tr>
                         {% endif %}
                     {% endif %}
+                    {% if not schedule and appointment.scheduledStart and appointment.scheduledStart >= now %}
+                        <tr>
+                            <th colspan="2">
+                                <button id="add-event-to-gcal" class="btn btn-primary darkblue"><i class="far fa-calendar-alt"></i> Add to Google Calendar</button>
+                            </th>
+                        </tr>
+                    {% endif %}
                 </table>
                 {% if schedule and walk_in_hours %}
                     <p>This is a drop in appointment. You do not need to sign up here. Simply show up to the AESC
@@ -200,6 +208,23 @@
 </div>
 
 <script type="text/javascript">
+    $('#add-event-to-gcal').click(function() {
+        let appt_id = $('#appt-id').val();
+        $.ajax({
+            type: "POST",
+            url: "{{ url_for('GoogleCalendarView:add_event_to_google_calendar') }}",
+            data: JSON.stringify({
+                'appt_id': appt_id,
+            }),
+            contentType: 'application/json;charset=UTF-8',
+            success: function (response) {
+                $('#add-event-to-gcal').html("Successfully added!");
+            },
+            error: function (error) {
+            }
+        });
+    });
+
     function scheduleAppointment(appt_id) {
         let course = '';
         $('#courses option:selected').each(function () {

--- a/writing_center/templates/macros/appointment_modal.html
+++ b/writing_center/templates/macros/appointment_modal.html
@@ -1,3 +1,5 @@
+{% import 'macros/login-to-google-calendar.html' as gcal_login %}
+
 <div class="modal fade" id="info-modal" tabindex="-1" role="dialog" aria-labelledby="modal-label" aria-hidden="true">
     <div class="modal-dialog modal-dialog-centered" role="document">
         <div class="modal-content">
@@ -163,9 +165,13 @@
                         <tr>
                             <th colspan="2">
                                 <input id="page-type" type="hidden" value="{{ add_google_calendar }}" />
-                                <button id="{% if "CREDENTIALS" in session %}add-event-to-gcal{% else %}login-to-google-calendar{% endif %}" class="btn btn-primary darkblue"><i class="far fa-calendar-alt"></i>
-                                    {% if "CREDENTIALS" in session %}Add To Google Calendar{% else %}Login To Add {% if 'student' in add_google_calendar %}Appointment{% else %}Shift{% endif %} To Your Google Calendar{% endif %}
-                                </button>
+                                {% if 'CREDENTIALS' in session %}
+                                    <button id="add-event-to-gcal" class="btn btn-primary darkblue"><i class="far fa-calendar-alt"></i>
+                                        Add To Google Calendar
+                                    </button>
+                                {% else %}
+                                    {{ gcal_login.login_to_google_calendar() }}
+                                {% endif %}
                             </th>
                         </tr>
                     {% endif %}
@@ -211,23 +217,6 @@
 </div>
 
 <script type="text/javascript">
-    $('#login-to-google-calendar').click(function() {
-        let page_type = $("#page-type").val();
-        $.ajax({
-            type: "POST",
-            url: "{{ url_for('GoogleCalendarView:login_to_google_calendar') }}",
-            data: JSON.stringify({
-                'page_type': page_type,
-            }),
-            contentType: 'application/json;charset=UTF-8',
-            success: function (response) {
-                window.location.replace(response);
-            },
-            error: function (error) {
-            }
-        });
-    });
-
     $('#add-event-to-gcal').click(function() {
         let appt_id = $('#appt-id').val();
         $.ajax({

--- a/writing_center/templates/macros/appointment_modal.html
+++ b/writing_center/templates/macros/appointment_modal.html
@@ -159,7 +159,7 @@
                             </tr>
                         {% endif %}
                     {% endif %}
-                    {% if not schedule and appointment.scheduledStart and appointment.scheduledStart >= now %}
+                    {% if not schedule and appointment.scheduledStart and appointment.scheduledStart >= now and add_google_calendar %}
                         <tr>
                             <th colspan="2">
                                 <button id="add-event-to-gcal" class="btn btn-primary darkblue"><i class="far fa-calendar-alt"></i> Add to Google Calendar</button>

--- a/writing_center/templates/macros/appointment_modal.html
+++ b/writing_center/templates/macros/appointment_modal.html
@@ -162,7 +162,10 @@
                     {% if not schedule and appointment.scheduledStart and appointment.scheduledStart >= now and add_google_calendar %}
                         <tr>
                             <th colspan="2">
-                                <button id="add-event-to-gcal" class="btn btn-primary darkblue"><i class="far fa-calendar-alt"></i> Add to Google Calendar</button>
+                                <input id="page-type" type="hidden" value="{{ add_google_calendar }}" />
+                                <button id="{% if "CREDENTIALS" in session %}add-event-to-gcal{% else %}login-to-google-calendar{% endif %}" class="btn btn-primary darkblue"><i class="far fa-calendar-alt"></i>
+                                    {% if "CREDENTIALS" in session %}Add To Google Calendar{% else %}Login To Add {% if 'student' in add_google_calendar %}Appointment{% else %}Shift{% endif %} To Google Calendar{% endif %}
+                                </button>
                             </th>
                         </tr>
                     {% endif %}
@@ -208,6 +211,23 @@
 </div>
 
 <script type="text/javascript">
+    $('#login-to-google-calendar').click(function() {
+        let page_type = $("#page-type").val();
+        $.ajax({
+            type: "POST",
+            url: "{{ url_for('GoogleCalendarView:login_to_google_calendar') }}",
+            data: JSON.stringify({
+                'page_type': page_type,
+            }),
+            contentType: 'application/json;charset=UTF-8',
+            success: function (response) {
+                window.location.replace(response);
+            },
+            error: function (error) {
+            }
+        });
+    });
+
     $('#add-event-to-gcal').click(function() {
         let appt_id = $('#appt-id').val();
         $.ajax({

--- a/writing_center/templates/macros/appointment_modal.html
+++ b/writing_center/templates/macros/appointment_modal.html
@@ -164,7 +164,7 @@
                             <th colspan="2">
                                 <input id="page-type" type="hidden" value="{{ add_google_calendar }}" />
                                 <button id="{% if "CREDENTIALS" in session %}add-event-to-gcal{% else %}login-to-google-calendar{% endif %}" class="btn btn-primary darkblue"><i class="far fa-calendar-alt"></i>
-                                    {% if "CREDENTIALS" in session %}Add To Google Calendar{% else %}Login To Add {% if 'student' in add_google_calendar %}Appointment{% else %}Shift{% endif %} To Google Calendar{% endif %}
+                                    {% if "CREDENTIALS" in session %}Add To Google Calendar{% else %}Login To Add {% if 'student' in add_google_calendar %}Appointment{% else %}Shift{% endif %} To Your Google Calendar{% endif %}
                                 </button>
                             </th>
                         </tr>

--- a/writing_center/templates/macros/login-to-google-calendar.html
+++ b/writing_center/templates/macros/login-to-google-calendar.html
@@ -1,22 +1,22 @@
-{% macro add_events_to_calendar(button_text) %}
+{% macro login_to_google_calendar() %}
     <div class="form-row">
         <input id="page-type" type="hidden" value="{% if "Appointments" in button_text %}student{% else %}tutor{% endif %}" />
-        <button id="add-events-to-gcal" class="btn btn-primary darkblue"><i class="far fa-calendar-alt"></i>
-            {{ button_text }}
+        <button id="" class="btn btn-primary darkblue login-to-google-calendar"><i class="far fa-calendar-alt"></i>
+            Login To Add {% if "Appointments" in button_text %}Appointments{% else %}Shifts{% endif %} To Your Google Calendar
         </button>
     </div>
     <script type="text/javascript">
-        $('#add-events-to-gcal').click(function() {
+        $('.login-to-google-calendar').click(function() {
             let page_type = $("#page-type").val();
             $.ajax({
                 type: "POST",
-                url: "{{ url_for('GoogleCalendarView:add_events_to_google_calendar') }}",
+                url: "{{ url_for('GoogleCalendarView:login_to_google_calendar') }}",
                 data: JSON.stringify({
                     'page_type': page_type
                 }),
                 contentType: 'application/json;charset=UTF-8',
                 success: function (response) {
-                    $('#add-events-to-gcal').html("Successfully added!");
+                    window.location.replace(response);
                 },
                 error: function (error) {
                 }

--- a/writing_center/templates/schedules/view_tutor_schedule.html
+++ b/writing_center/templates/schedules/view_tutor_schedule.html
@@ -7,7 +7,7 @@
         <h1><b>View Tutor Schedule</b></h1>
         <p>Displays the appointments a tutor is assigned to.</p>
     </div>
-    {{ gcal_macros.add_events_to_calendar("Add Upcoming Shifts To Google Calendar") }}
+    {{ gcal_macros.add_events_to_calendar("Add All Upcoming Shifts To Google Calendar") }}
     <div id="results"></div>
     <hr>
     <div class="row">
@@ -134,7 +134,8 @@
                         url: "{{ url_for('AppointmentsView:load_appointment_data') }}",
                         data: JSON.stringify({
                             'id': info.event.id,
-                            'subDelete': true
+                            'subDelete': true,
+                            'gcalAdd': 'tutor',
                         }),
                         contentType: 'application/json;charset=UTF-8',
                         success: function (response) {

--- a/writing_center/templates/schedules/view_tutor_schedule.html
+++ b/writing_center/templates/schedules/view_tutor_schedule.html
@@ -7,7 +7,11 @@
         <h1><b>View Tutor Schedule</b></h1>
         <p>Displays the appointments a tutor is assigned to.</p>
     </div>
-    {{ gcal_macros.add_events_to_calendar("Add All Upcoming Shifts To Google Calendar") }}
+    {% if 'CREDENTIALS' in session %}
+        {{ gcal_events.add_events_to_calendar("Add All Upcoming Appointments To Google Calendar") }}
+    {% else %}
+        {{ gcal_login.login_to_google_calendar() }}
+    {% endif %}
     <div id="results"></div>
     <hr>
     <div class="row">

--- a/writing_center/templates/schedules/view_tutor_schedule.html
+++ b/writing_center/templates/schedules/view_tutor_schedule.html
@@ -7,6 +7,7 @@
         <h1><b>View Tutor Schedule</b></h1>
         <p>Displays the appointments a tutor is assigned to.</p>
     </div>
+    {{ gcal_macros.add_events_to_calendar("Add Upcoming Shifts To Google Calendar") }}
     <div id="results"></div>
     <hr>
     <div class="row">

--- a/writing_center/templates/statistics/statistics.html
+++ b/writing_center/templates/statistics/statistics.html
@@ -8,7 +8,7 @@
         <p>Displays various statistics over the selected range.</p>
     </div>
     <div id="results">
-        {% include 'statistics/statistics_tables.html'%}
+        {% include 'statistics/statistics_tables.html' %}
     </div>
 
 

--- a/writing_center/templates/statistics/statistics_tables.html
+++ b/writing_center/templates/statistics/statistics_tables.html
@@ -8,7 +8,7 @@
         </div>
     </div>
     <div class="form-row">
-        {% include ('macros/date_selector.html') %}
+        {% include 'macros/date_selector.html' %}
         <div class="form-group col-md-12">
             <table id="total-visits"  class="table table-striped table-bordered">
                 <thead>

--- a/writing_center/templates/writing_center_base.html
+++ b/writing_center/templates/writing_center_base.html
@@ -1,5 +1,6 @@
 <!DOCTYPE html>
-{% import 'macros/add-events-to-calendar.html' as gcal_macros %}
+{% import 'macros/add-events-to-calendar.html' as gcal_events %}
+{% import 'macros/login-to-google-calendar.html' as gcal_login %}
 
 {% block html_attribs %}
     <html lang="en">

--- a/writing_center/templates/writing_center_base.html
+++ b/writing_center/templates/writing_center_base.html
@@ -1,4 +1,5 @@
 <!DOCTYPE html>
+{% import 'macros/add-events-to-calendar.html' as gcal_macros %}
 
 {% block html_attribs %}
     <html lang="en">
@@ -75,6 +76,9 @@
             <!-- JQuery/JS for slim-select -->
             <script src="https://cdnjs.cloudflare.com/ajax/libs/slim-select/1.22.0/slimselect.min.js"></script>
             <link href="https://cdnjs.cloudflare.com/ajax/libs/slim-select/1.22.0/slimselect.min.css" rel="stylesheet">
+
+            <!-- Font Awesome -->
+            <script src="https://kit.fontawesome.com/ef15f9ef70.js" crossorigin="anonymous"></script>
 
             {% block styles %}
                 <!-- Full Calendar CSS -->


### PR DESCRIPTION
## Description

This PR will add the ability to add your writing center appointments/shifts to your Google Calendar.

After logging into your Bethel Google Account by clicking on a "login to google calendar" button, you can then either click a button to add all upcoming events to Google Calendar, or click on a specific event and add that specific event to your Calendar. Clicking both buttons won't create duplicate events.

Adding appointments to your Google Calendar is supported if you are a student or tutor.

Fixes #245 

## Size and Type of change

- Small Change - 1 person needs to review this

- New feature

- Venv update needed
    - Install new requirements

- Config update needed
    - Add `GC_CLIENT_SECRET` location to config

- Add `gc_client_secret.json` file to project

## How Has This Been Tested?

Locally I implemented the changes and tested adding appointments to my Google Calendar using both buttons (add specific event/add all upcoming events)

I then moved the code over to xp and did the same tests and they succeeded.

## Checklist:

Only check what applies and what you have done.

- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have tested on multiple browsers (Chrome, Firefox, Safari, IE suite)