### PR TITLE
Mobile Viewing Fixes

### DIFF
--- a/writing_center/static/assets/writing_center.css
+++ b/writing_center/static/assets/writing_center.css
@@ -28,7 +28,7 @@ a.nav-link:focus, a.nav-link:hover.active {
     color: white !important;
 }
 
-.banned-users, .scheduled-appointments, .writing-center-users {
+.banned-users, .scheduled-appointments, .writing-center-users, #results {
     display: inherit;
     overflow: auto;
 }
@@ -243,7 +243,7 @@ ul.list-group{
     margin-left: 20px;
 }
 
-.login-to-google-calendar {
+.login-to-google-calendar, .fc-toolbar.fc-header-toolbar {
     overflow: auto;
 }
 

--- a/writing_center/static/assets/writing_center.css
+++ b/writing_center/static/assets/writing_center.css
@@ -28,6 +28,11 @@ a.nav-link:focus, a.nav-link:hover.active {
     color: white !important;
 }
 
+.banned-users, .scheduled-appointments, .writing-center-users {
+    display: inherit;
+    overflow: auto;
+}
+
 body {
     background: #fff;
     color: #222;
@@ -221,12 +226,25 @@ ul.list-group{
     background: yellow !important;
 }
 
+@media screen and (max-width: 450px) {
+    .fc-unthemed .fc-today-button {
+        display: none;
+    }
+    .fc-center {
+        text-align: center;
+    }
+}
+
 .form-check-input {
     margin-left: 0px !important;
 }
 
 .form-check-label {
     margin-left: 20px;
+}
+
+.login-to-google-calendar {
+    overflow: auto;
 }
 
 .nav.margins {

--- a/writing_center/templates/appointments/appointments_and_walk_ins.html
+++ b/writing_center/templates/appointments/appointments_and_walk_ins.html
@@ -31,83 +31,85 @@
                     <h3>Scheduled appointments:</h3>
                 </div>
             </div>
-            <table id="table"  class="table table-striped table-bordered">
-                <thead>
-                    <tr>
-                        <th data-toggle="tooltip" data-placement="top" title="Student">Student</th>
-                        <th data-toggle="tooltip" data-placement="top" title="Date">Date</th>
-                        <th data-toggle="tooltip" data-placement="top" title="Start Time">Start Time</th>
-                        <th data-toggle="tooltip" data-placement="top" title="End Time">End Time</th>
-                        <th data-toggle="tooltip" data-placement="top" title="Start Appointment">Start/Continue/End Appointment</th>
-                        <th data-toggle="tooltip" data-placement="top" title="Mark/Unmark as No Show">Mark/Unmark as No Show</th>
-                        <th data-toggle="tooltip" data-placement="top" title="Mark/Unmark as Multilingual">Mark/Unmark as Multilingual</th>
-                        <th data-toggle="tooltip" data-placement="top" title="View More Info">View More Info</th>
-                    </tr>
-                </thead>
-                <tbody>
-                    {% if appointments|length > 0 %}
-                        {% for appointment in appointments %}
-                            <tr>
-                                <td>
-                                    {{ users[appointment.student_id] }}
-                                </td>
-                                <td>
-                                    {% if appointment.scheduledStart %}
-                                        {{ appointment.scheduledStart|datetimeformat('%m/%d/%y') }}
-                                    {% elif appointment.actualStart %}
-                                        {{ appointment.actualStart|datetimeformat('%m/%d/%y') }}
-                                    {% endif %}
-                                </td>
-                                <td>
-                                    {% if appointment.scheduledStart %}
-                                        {{ appointment.scheduledStart|datetimeformat }}
-                                    {% elif appointment.actualStart %}
-                                        {{ appointment.actualStart|datetimeformat }}
-                                    {% endif %}
-                                </td>
-                                <td>
-                                    {% if appointment.scheduledEnd %}
-                                        {{ appointment.scheduledEnd|datetimeformat }}
-                                    {% elif appointment.actualEnd %}
-                                        {{ appointment.actualEnd|datetimeformat }}
-                                    {% endif %}
-                                </td>
-                                <td>
-                                    {% if not appointment.actualStart %}
-                                        <a id="start" href="{{ url_for('AppointmentsView:start_appointment', appt_id=appointment.id) }}"
-                                           class="btn btn-primary btn-success">Start Appointment</a>
-                                    {% elif not appointment.actualEnd %}
-                                        <a id="End" href="{{ url_for('AppointmentsView:in_progress_appointment', appt_id=appointment.id) }}"
-                                           class="btn btn-primary btn-danger">End Appointment</a>
-                                    {% else %}
-                                        <a id="continue" href="{{ url_for('AppointmentsView:in_progress_appointment', appt_id=appointment.id) }}"
-                                           class="btn btn-primary background-blue">Continue Appointment</a>
-                                    {% endif %}
-                                </td>
-                                <td>
-                                    {% if appointment.noShow == 0 or not appointment.noShow %}
-                                        <a id="no-show" href="{{ url_for('AppointmentsView:toggle_no_show', appt_id=appointment.id) }}"
-                                           class="btn btn-primary btn-danger">Mark as No Show</a>
-                                    {% elif appointment.noShow == 1 %}
-                                        <a id="revert-no-show" href="{{ url_for('AppointmentsView:toggle_no_show', appt_id=appointment.id) }}"
-                                           class="btn btn-primary btn-danger">Revert No Show</a>
-                                    {% endif %}
-                                </td>
-                                <td>
-                                    {% if appointment.multilingual == 0 or not appointment.multilingual %}
-                                        <a id="multilingual" href="{{ url_for('AppointmentsView:toggle_multilingual', appt_id=appointment.id) }}"
-                                           class="btn btn-primary btn-danger">Mark as Multilingual</a>
-                                    {% elif appointment.multilingual == 1 %}
-                                        <a id="revert-multilingual" href="{{ url_for('AppointmentsView:toggle_multilingual', appt_id=appointment.id) }}"
-                                           class="btn btn-primary btn-danger">Revert Multilingual</a>
-                                    {% endif %}
-                                </td>
-                                <td><input type="button" class="btn btn-primary darkblue" value="More Info" onclick="viewInfo({{ appointment.id }})"></td>
-                            </tr>
-                        {% endfor %}
-                    {% endif %}
-                </tbody>
-            </table>
+            <div class="scheduled-appointments">
+                <table id="table"  class="table table-striped table-bordered">
+                    <thead>
+                        <tr>
+                            <th data-toggle="tooltip" data-placement="top" title="Student">Student</th>
+                            <th data-toggle="tooltip" data-placement="top" title="Date">Date</th>
+                            <th data-toggle="tooltip" data-placement="top" title="Start Time">Start Time</th>
+                            <th data-toggle="tooltip" data-placement="top" title="End Time">End Time</th>
+                            <th data-toggle="tooltip" data-placement="top" title="Start Appointment">Start/Continue/End Appointment</th>
+                            <th data-toggle="tooltip" data-placement="top" title="Mark/Unmark as No Show">Mark/Unmark as No Show</th>
+                            <th data-toggle="tooltip" data-placement="top" title="Mark/Unmark as Multilingual">Mark/Unmark as Multilingual</th>
+                            <th data-toggle="tooltip" data-placement="top" title="View More Info">View More Info</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {% if appointments|length > 0 %}
+                            {% for appointment in appointments %}
+                                <tr>
+                                    <td>
+                                        {{ users[appointment.student_id] }}
+                                    </td>
+                                    <td>
+                                        {% if appointment.scheduledStart %}
+                                            {{ appointment.scheduledStart|datetimeformat('%m/%d/%y') }}
+                                        {% elif appointment.actualStart %}
+                                            {{ appointment.actualStart|datetimeformat('%m/%d/%y') }}
+                                        {% endif %}
+                                    </td>
+                                    <td>
+                                        {% if appointment.scheduledStart %}
+                                            {{ appointment.scheduledStart|datetimeformat }}
+                                        {% elif appointment.actualStart %}
+                                            {{ appointment.actualStart|datetimeformat }}
+                                        {% endif %}
+                                    </td>
+                                    <td>
+                                        {% if appointment.scheduledEnd %}
+                                            {{ appointment.scheduledEnd|datetimeformat }}
+                                        {% elif appointment.actualEnd %}
+                                            {{ appointment.actualEnd|datetimeformat }}
+                                        {% endif %}
+                                    </td>
+                                    <td>
+                                        {% if not appointment.actualStart %}
+                                            <a id="start" href="{{ url_for('AppointmentsView:start_appointment', appt_id=appointment.id) }}"
+                                               class="btn btn-primary btn-success">Start Appointment</a>
+                                        {% elif not appointment.actualEnd %}
+                                            <a id="End" href="{{ url_for('AppointmentsView:in_progress_appointment', appt_id=appointment.id) }}"
+                                               class="btn btn-primary btn-danger">End Appointment</a>
+                                        {% else %}
+                                            <a id="continue" href="{{ url_for('AppointmentsView:in_progress_appointment', appt_id=appointment.id) }}"
+                                               class="btn btn-primary background-blue">Continue Appointment</a>
+                                        {% endif %}
+                                    </td>
+                                    <td>
+                                        {% if appointment.noShow == 0 or not appointment.noShow %}
+                                            <a id="no-show" href="{{ url_for('AppointmentsView:toggle_no_show', appt_id=appointment.id) }}"
+                                               class="btn btn-primary btn-danger">Mark as No Show</a>
+                                        {% elif appointment.noShow == 1 %}
+                                            <a id="revert-no-show" href="{{ url_for('AppointmentsView:toggle_no_show', appt_id=appointment.id) }}"
+                                               class="btn btn-primary btn-danger">Revert No Show</a>
+                                        {% endif %}
+                                    </td>
+                                    <td>
+                                        {% if appointment.multilingual == 0 or not appointment.multilingual %}
+                                            <a id="multilingual" href="{{ url_for('AppointmentsView:toggle_multilingual', appt_id=appointment.id) }}"
+                                               class="btn btn-primary btn-danger">Mark as Multilingual</a>
+                                        {% elif appointment.multilingual == 1 %}
+                                            <a id="revert-multilingual" href="{{ url_for('AppointmentsView:toggle_multilingual', appt_id=appointment.id) }}"
+                                               class="btn btn-primary btn-danger">Revert Multilingual</a>
+                                        {% endif %}
+                                    </td>
+                                    <td><input type="button" class="btn btn-primary darkblue" value="More Info" onclick="viewInfo({{ appointment.id }})"></td>
+                                </tr>
+                            {% endfor %}
+                        {% endif %}
+                    </tbody>
+                </table>
+            </div>
             {% if appointments|length == 0 %}
                 You current do no have any scheduled appointments
             {% endif %}

--- a/writing_center/templates/users/view_all_users.html
+++ b/writing_center/templates/users/view_all_users.html
@@ -6,62 +6,64 @@
     <div class="jumbotron">
         <h3>Writing Center Users</h3>
     </div>
-    <form>
-        <div class="form-row">
-            <div class="form-group col-md-12">
-                <table id="table"  class="table table-striped table-bordered">
-                    <thead>
-                        <tr>
-                            <th data-toggle="tooltip" data-placement="top" title="User Last Name">Last</th>
-                            <th data-toggle="tooltip" data-placement="top" title="User First Name">First</th>
-                            <th data-toggle="tooltip" data-placement="top" title="User Email">Email</th>
-                            <th data-toggle="tooltip" data-placement="top" title="User Role">Role(s)</th>
-                            <th data-toggle="tooltip" data-placement="top" title="Act As This User">Change User</th>
-                            <th data-toggle="tooltip" data-placement="top" title="Edit User">Edit</th>
-                            <th>✓</th>
-                        </tr>
-                        <tr>
-                            <th colspan="6"></th>
-                            <th colspan="1">
-                                <button id="deactivate-users" type="button" class="btn btn-primary btn-danger hover-bright">Deactivate</button>
-                            </th>
-                        </tr>
-                    </thead>
-                    <tbody>
-                        {% for user in users %}
+    <div class="writing-center-users">
+        <form>
+            <div class="form-row">
+                <div class="form-group col-md-12">
+                    <table id="table"  class="table table-striped table-bordered">
+                        <thead>
                             <tr>
-                                <td>
-                                    {{ users[user]['lastName'] }}
-                                </td>
-                                <td>
-                                    {{ users[user]['firstName'] }}
-                                </td>
-                                <td>
-                                    {{ users[user]['email'] }}
-                                </td>
-                                <td>
-                                    {{ users[user]['roles'] }}
-                                </td>
-                                <td>
-                                    {% if users[user]['username'] == session['USERNAME'] %}
-                                        N/A
-                                    {% else %}
-                                        <a id="act-as" href='{{ url_for('UsersView:act_as_user', user_id=users[user]['id']) }}' class="btn btn-primary background-blue">Act As User</a>
-                                    {% endif %}
-                                </td>
-                                <td>
-                                    <a id="edit" href='{{ url_for('UsersView:edit_user', user_id=users[user]['id']) }}' class="btn btn-primary background-blue">Edit</a>
-                                </td>
-                                <td class="text-center">
-                                    <input type="checkbox" value="{{ users[user]['id'] }}" class="deactivate-checkbox">
-                                </td>
+                                <th data-toggle="tooltip" data-placement="top" title="User Last Name">Last</th>
+                                <th data-toggle="tooltip" data-placement="top" title="User First Name">First</th>
+                                <th data-toggle="tooltip" data-placement="top" title="User Email">Email</th>
+                                <th data-toggle="tooltip" data-placement="top" title="User Role">Role(s)</th>
+                                <th data-toggle="tooltip" data-placement="top" title="Act As This User">Change User</th>
+                                <th data-toggle="tooltip" data-placement="top" title="Edit User">Edit</th>
+                                <th>✓</th>
                             </tr>
-                        {% endfor %}
-                    </tbody>
-                </table>
+                            <tr>
+                                <th colspan="6"></th>
+                                <th colspan="1">
+                                    <button id="deactivate-users" type="button" class="btn btn-primary btn-danger hover-bright">Deactivate</button>
+                                </th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            {% for user in users %}
+                                <tr>
+                                    <td>
+                                        {{ users[user]['lastName'] }}
+                                    </td>
+                                    <td>
+                                        {{ users[user]['firstName'] }}
+                                    </td>
+                                    <td>
+                                        {{ users[user]['email'] }}
+                                    </td>
+                                    <td>
+                                        {{ users[user]['roles'] }}
+                                    </td>
+                                    <td>
+                                        {% if users[user]['username'] == session['USERNAME'] %}
+                                            N/A
+                                        {% else %}
+                                            <a id="act-as" href='{{ url_for('UsersView:act_as_user', user_id=users[user]['id']) }}' class="btn btn-primary background-blue">Act As User</a>
+                                        {% endif %}
+                                    </td>
+                                    <td>
+                                        <a id="edit" href='{{ url_for('UsersView:edit_user', user_id=users[user]['id']) }}' class="btn btn-primary background-blue">Edit</a>
+                                    </td>
+                                    <td class="text-center">
+                                        <input type="checkbox" value="{{ users[user]['id'] }}" class="deactivate-checkbox">
+                                    </td>
+                                </tr>
+                            {% endfor %}
+                        </tbody>
+                    </table>
+                </div>
             </div>
-        </div>
-    </form>
+        </form>
+    </div>
 
     <script>
         $(document).ready( function () {


### PR DESCRIPTION
## Description

There were some issues viewing Writing Center from a mobile device. I was able to make everything look better by adding scroll bars to tables, buttons, ect. that overflowed the screen. I also removed the "Today" button from the calendar for when the screen was smaller than 450px. Without it, the calendar looks way less messy

Fixes #31 

## Size and Type of change

Delete any of these you don't use.

- Small Change - 1 person needs to review this

- Bug fix

## How Has This Been Tested?

Please briefly describe the tests that you ran to verify your changes.

I made changes and then viewed those changes through google chromes inspect tool which allowed me to view how the screen would look from many different mobile devices.

## Checklist:

Only check what applies and what you have done.

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have tested on multiple browsers (Chrome, Firefox, Safari, IE suite)