### PR TITLE
Adds assignment textfield constraint

### DIFF
--- a/writing_center/templates/macros/appointment_modal.html
+++ b/writing_center/templates/macros/appointment_modal.html
@@ -105,7 +105,7 @@
                         <tr>
                             <th>Describe Your Assignment</th>
                             <td>
-                                <textarea id="assignment" name="assignment" class="form-control"></textarea>
+                                <textarea id="assignment" name="assignment" class="form-control" maxlength="255"></textarea>
                             </td>
                         </tr>
                     {% endif %}


### PR DESCRIPTION
- Too long of an assignment description in the textfield can lead to this error.

## Description

A student was receiving the error: "Error! Appointment Not Scheduled!" They could submit an appointment without a description but not with one. I am thinking they just had typed in too much text into the description leading to this error.

Fixes # (ITS-235528)

## Size and Type of change

Delete any of these you don't use.

- Small Change - 1 person needs to review this

- Bug fix

## How Has This Been Tested?

Please briefly describe the tests that you ran to verify your changes.

I reproduced this error on my machine by typing in too much text. By limiting the text this error can't be produced by having too much text (unless someone typed in characters that became encoded strangely).

## Checklist:

Only check what applies and what you have done.

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have tested on multiple browsers (Chrome, Firefox, Safari, IE suite)